### PR TITLE
ast: Specify types for iota-based constants

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -4,9 +4,10 @@ package ast
 import (
 	"bytes"
 	"fmt"
+	"strings"
+
 	textm "github.com/yuin/goldmark/text"
 	"github.com/yuin/goldmark/util"
-	"strings"
 )
 
 // A NodeType indicates what type a node belongs to.
@@ -412,7 +413,7 @@ type WalkStatus int
 
 const (
 	// WalkStop indicates no more walking needed.
-	WalkStop = iota + 1
+	WalkStop WalkStatus = iota + 1
 
 	// WalkSkipChildren indicates that Walk wont walk on children of current
 	// node.

--- a/ast/block.go
+++ b/ast/block.go
@@ -2,8 +2,9 @@ package ast
 
 import (
 	"fmt"
-	textm "github.com/yuin/goldmark/text"
 	"strings"
+
+	textm "github.com/yuin/goldmark/text"
 )
 
 // A BaseBlock struct implements the Node interface.
@@ -397,7 +398,7 @@ type HTMLBlockType int
 
 const (
 	// HTMLBlockType1 represents type 1 html blocks
-	HTMLBlockType1 = iota + 1
+	HTMLBlockType1 HTMLBlockType = iota + 1
 	// HTMLBlockType2 represents type 2 html blocks
 	HTMLBlockType2
 	// HTMLBlockType3 represents type 3 html blocks

--- a/ast/inline.go
+++ b/ast/inline.go
@@ -447,7 +447,7 @@ type AutoLinkType int
 
 const (
 	// AutoLinkEmail indicates that an autolink is an email address.
-	AutoLinkEmail = iota + 1
+	AutoLinkEmail AutoLinkType = iota + 1
 	// AutoLinkURL indicates that an autolink is a generic URL.
 	AutoLinkURL
 )


### PR DESCRIPTION
Including the type of a constant improves discoverability because the
constant is listed next to the type in the godocs.

Before:

```
$ go doc -all . WalkStatus
type WalkStatus int
    WalkStatus represents a current status of the Walk function.
```

After:

```shell
$ go doc -all . WalkStatus
type WalkStatus int
    WalkStatus represents a current status of the Walk function.

const (
	// WalkStop indicates no more walking needed.
	WalkStop WalkStatus = iota + 1

	// WalkSkipChildren indicates that Walk wont walk on children of current
	// node.
	WalkSkipChildren

	// WalkContinue indicates that Walk can continue to walk.
	WalkContinue
)
```

This commit the `iota`-based constants in the AST package to follow
this.