### PR TITLE
fix parser issue with input ending with non-space characters

### DIFF
--- a/_test/spec.json
+++ b/_test/spec.json
@@ -5190,5 +5190,13 @@
     "start_line": 9365,
     "end_line": 9369,
     "section": "Textual content"
+  },
+  {
+	"markdown": " ```\n aaa\naaa\n```",
+	"html": "<pre><code>aaa\naaa\n</code></pre>\n",
+	"example": 650,
+	"start_line": 0,
+	"end_line": 0,
+	"section": "Fenced code blocks"
   }
 ]

--- a/parser/atx_heading.go
+++ b/parser/atx_heading.go
@@ -223,7 +223,7 @@ func parseLastLineAttributes(node ast.Node, reader text.Reader, pc Context) {
 		}
 		lr.Advance(1)
 	}
-	if ok && util.IsBlank(line[end.Stop:]) {
+	if ok && util.IsBlank(lr.Source()[end.Stop:]) {
 		for _, attr := range attrs {
 			node.SetAttribute(attr.Name, attr.Value)
 		}

--- a/text/reader.go
+++ b/text/reader.go
@@ -1,10 +1,11 @@
 package text
 
 import (
-	"github.com/yuin/goldmark/util"
 	"io"
 	"regexp"
 	"unicode/utf8"
+
+	"github.com/yuin/goldmark/util"
 )
 
 const invalidValue = -1
@@ -83,9 +84,17 @@ type reader struct {
 
 // NewReader return a new Reader that can read UTF-8 bytes .
 func NewReader(source []byte) Reader {
+	sourceLength := len(source)
+	if sourceLength > 0 {
+		if !util.IsSpace(source[sourceLength-1]) {
+			source = append(source, ' ')
+			sourceLength++
+		}
+	}
+
 	r := &reader{
 		source:       source,
-		sourceLength: len(source),
+		sourceLength: sourceLength,
 	}
 	r.ResetPosition()
 	return r


### PR DESCRIPTION
Discovered that the input string that ends with non-whitespace characters caused an incorrect parsing. For example, the following input (fenced code block with no newlines at the end)

> \`\`\`
> abc
>  \`\`\`

is parsed as a fenced code block followed by another paragraph with text value of "`".

I don't know if the spec requires all input string to end with 1+ newline characters or not, but, appending a whitespace character at the end fixed most of my own use cases. Feel free to close/ignore if you have a better fix 😄 .

Thanks!