### PR TITLE
Improve display of footnote backlinks

### DIFF
--- a/extension/_test/footnote.txt
+++ b/extension/_test/footnote.txt
@@ -12,7 +12,7 @@ That's some text with a footnote.[^1]
 <ol>
 <li id="fn:1" role="doc-endnote">
 <p>And that's the footnote.</p>
-<p>That's the second paragraph.<a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#8617;</a></p>
+<p>That's the second paragraph. <a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
 </li>
 </ol>
 </section>
@@ -26,7 +26,7 @@ That's some text with a footnote.[^1]
 <hr>
 <ol>
 <li id="fn:1" role="doc-endnote">
-<p>0	[^]:<a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#8617;</a></p>
+<p>0	[^]: <a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
 </li>
 </ol>
 </section>

--- a/extension/footnote.go
+++ b/extension/footnote.go
@@ -237,10 +237,10 @@ func (r *FootnoteHTMLRenderer) renderFootnoteBackLink(w util.BufWriter, source [
 	if entering {
 		n := node.(*ast.FootnoteBackLink)
 		is := strconv.Itoa(n.Index)
-		_, _ = w.WriteString(`<a href="#fnref:`)
+		_, _ = w.WriteString(` <a href="#fnref:`)
 		_, _ = w.WriteString(is)
 		_, _ = w.WriteString(`" class="footnote-backref" role="doc-backlink">`)
-		_, _ = w.WriteString("&#8617;")
+		_, _ = w.WriteString("&#x21a9;&#xfe0e;")
 		_, _ = w.WriteString(`</a>`)
 	}
 	return gast.WalkContinue, nil


### PR DESCRIPTION
This makes three changes to backlinks:

- Inserts a space before `<a href='…'>↩</a>` to make it look better
- Uses hexadecimal references (`&#x…;`) instead of decimal references for clarity
- Adds U+FE0E VARIATION SELECTOR 15 to the ↩ to suppress emojification on both iOS and Edge on Windows

If variation selector 15 isn't appended to the ↩, then the return arrow will show up as an emoji on iOS and Edge for Windows. The Pandoc project has already run into this quirk as documented on https://github.com/jgm/pandoc/issues/5469 and they've pushed a change for their Markdown processor already.

Note: I changed the tests to match the new HTML output. Further, HTML like this works fine in browsers I use. However, I have not tested this change in live code like a custom Hugo build. 