### PR TITLE
Put header id to generator

### DIFF
--- a/parser/atx_heading.go
+++ b/parser/atx_heading.go
@@ -171,9 +171,11 @@ func (b *atxHeadingParser) Close(node ast.Node, reader text.Reader, pc Context) 
 	}
 
 	if b.AutoHeadingID {
-		_, ok := node.AttributeString("id")
+		id, ok := node.AttributeString("id")
 		if !ok {
 			generateAutoHeadingID(node.(*ast.Heading), reader, pc)
+		} else {
+			pc.IDs().Put(id.([]byte))
 		}
 	}
 }

--- a/parser/setext_headings.go
+++ b/parser/setext_headings.go
@@ -108,9 +108,11 @@ func (b *setextHeadingParser) Close(node ast.Node, reader text.Reader, pc Contex
 	}
 
 	if b.AutoHeadingID {
-		_, ok := node.AttributeString("id")
+		id, ok := node.AttributeString("id")
 		if !ok {
 			generateAutoHeadingID(heading, reader, pc)
+		} else {
+			pc.IDs().Put(id.([]byte))
 		}
 	}
 }


### PR DESCRIPTION
When automatically generating header identifiers, it would be nice to know about those already defined in the source document so that there are less conflicts.