### PR TITLE
Additional <thead>, <tr>, <th>, <td> attributes render

### DIFF
--- a/renderer/html/html.go
+++ b/renderer/html/html.go
@@ -399,8 +399,11 @@ func (r *Renderer) renderTextBlock(w util.BufWriter, source []byte, n ast.Node, 
 
 // ThematicAttributeFilter defines attribute names which hr elements can have.
 var ThematicAttributeFilter = GlobalAttributeFilter.Extend(
-	[]byte("align"),
-	[]byte("color"),
+	[]byte("align"),   // [Deprecated]
+	[]byte("color"),   // [Not Standardized]
+	[]byte("noshade"), // [Deprecated]
+	[]byte("size"),    // [Deprecated]
+	[]byte("width"),   // [Deprecated]
 )
 
 func (r *Renderer) renderThematicBreak(w util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {


### PR DESCRIPTION
Bumped into a couple of issues with table headers rendering and it required adding these attributes render.

In particular, `align` used in `<tr>` misbehaved in my use case while working fine in `<td`>.

So I have to pass `class` attribute instead when necessary.

Also `align` is marked as deprecated, although I don't think it was the reason for my issue.