### PR TITLE
Link to CommonMark website in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ As mentioned above, CommonMark is too complicated and hard to implement, so Mark
 Features
 ----------------------
 
-- **Standard compliant.**  goldmark gets full compliance with the latest CommonMark spec.
+- **Standard compliant.**  goldmark gets full compliance with the latest [CommonMark](https://commonmark.org/) specification.
 - **Extensible.**  Do you want to add a `@username` mention syntax to Markdown?
   You can easily do it in goldmark. You can add your AST nodes,
   parsers for block level elements, parsers for inline level elements,


### PR DESCRIPTION
Link to the CommonMark website to explicitly reference what it is, and to help users unfamiliar with it to discover and navigate to it.

CommonMark is mentioned very early in the README. Here it is a subheadline. I decided to not link here but in this features section instead where it is listed as one of the features. The subheadline seems more fitting as a short, pure text for those knowing about it.

The link is to the main website rather than the specification as users unfamiliar with it will want to land on the landing page with a description of what it is rather than a technical specification. The specification page does not immediately and obviously link back to the main website.

The shortened term spec is being extended to its full word specification for clarity and discoverability.