### PR TITLE
fix bug: BaseNode.RemoveChildren only set the first child as nil

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -236,10 +236,12 @@ func (n *BaseNode) RemoveChild(self, v Node) {
 
 // RemoveChildren implements Node.RemoveChildren .
 func (n *BaseNode) RemoveChildren(self Node) {
-	for c := n.firstChild; c != nil; c = c.NextSibling() {
+	for c := n.firstChild; c != nil; {
 		c.SetParent(nil)
 		c.SetPreviousSibling(nil)
+		next := c.NextSibling()
 		c.SetNextSibling(nil)
+		c = next
 	}
 	n.firstChild = nil
 	n.lastChild = nil

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -1,0 +1,18 @@
+package ast
+
+import "testing"
+
+func TestRemoveChildren(t *testing.T) {
+	root := NewDocument()
+
+	node1 := NewDocument()
+
+	node2 := NewDocument()
+
+	root.AppendChild(root, node1)
+	root.AppendChild(root, node2)
+
+	root.RemoveChildren(root)
+
+	t.Logf("%+v", node2.PreviousSibling())
+}


### PR DESCRIPTION
 if do c.SetNextSibling(nil) and c = c.NextSibling(). After remove the first child the var c is always nil.the next child will not be set nil