### PR TITLE
Named footnotes

### DIFF
--- a/extension/_test/footnote.txt
+++ b/extension/_test/footnote.txt
@@ -66,3 +66,21 @@ test![^1]
 </ol>
 </section>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
+
+
+6
+//- - - - - - - - -//
+That's some text with a footnote.[^mynameisjeff]
+
+[^mynameisjeff]: And that's the footnote.
+//- - - - - - - - -//
+<p>That's some text with a footnote.<sup id="fnref:mynameisjeff"><a href="#fn:mynameisjeff" class="footnote-ref" role="doc-noteref">1</a></sup></p>
+<section class="footnotes" role="doc-endnotes">
+<hr>
+<ol>
+<li id="fn:mynameisjeff" role="doc-endnote">
+<p>And that's the footnote. <a href="#fnref:mynameisjeff" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+</li>
+</ol>
+</section>
+//= = = = = = = = = = = = = = = = = = = = = = = =//

--- a/extension/ast/footnote.go
+++ b/extension/ast/footnote.go
@@ -10,6 +10,7 @@ import (
 type FootnoteLink struct {
 	gast.BaseInline
 	Index int
+	Ref   []byte
 }
 
 // Dump implements Node.Dump.
@@ -28,9 +29,10 @@ func (n *FootnoteLink) Kind() gast.NodeKind {
 }
 
 // NewFootnoteLink returns a new FootnoteLink node.
-func NewFootnoteLink(index int) *FootnoteLink {
+func NewFootnoteLink(index int, ref []byte) *FootnoteLink {
 	return &FootnoteLink{
 		Index: index,
+		Ref:   ref,
 	}
 }
 

--- a/extension/ast/footnote.go
+++ b/extension/ast/footnote.go
@@ -41,6 +41,7 @@ func NewFootnoteLink(index int, ref []byte) *FootnoteLink {
 type FootnoteBackLink struct {
 	gast.BaseInline
 	Index int
+	Ref   []byte
 }
 
 // Dump implements Node.Dump.
@@ -59,9 +60,10 @@ func (n *FootnoteBackLink) Kind() gast.NodeKind {
 }
 
 // NewFootnoteBackLink returns a new FootnoteBackLink node.
-func NewFootnoteBackLink(index int) *FootnoteBackLink {
+func NewFootnoteBackLink(index int, ref []byte) *FootnoteBackLink {
 	return &FootnoteBackLink{
 		Index: index,
+		Ref:   ref,
 	}
 }
 

--- a/extension/footnote.go
+++ b/extension/footnote.go
@@ -194,11 +194,12 @@ func (a *footnoteASTTransformer) Transform(node *gast.Document, reader text.Read
 		if fc := container.LastChild(); fc != nil && gast.IsParagraph(fc) {
 			container = fc
 		}
-		index := footnote.(*ast.Footnote).Index
-		if index < 0 {
+		n := footnote.(*ast.Footnote)
+		if n.Index < 0 {
 			list.RemoveChild(list, footnote)
 		} else {
-			container.AppendChild(container, ast.NewFootnoteBackLink(index))
+			backlink := ast.NewFootnoteBackLink(n.Index, n.Ref)
+			container.AppendChild(container, backlink)
 		}
 		footnote = next
 	}

--- a/extension/footnote.go
+++ b/extension/footnote.go
@@ -149,6 +149,7 @@ func (s *footnoteParser) Parse(parent gast.Node, block text.Reader, pc parser.Co
 		return nil
 	}
 	index := 0
+	var ref []byte
 	for def := list.FirstChild(); def != nil; def = def.NextSibling() {
 		d := def.(*ast.Footnote)
 		if bytes.Equal(d.Ref, value) {
@@ -157,6 +158,7 @@ func (s *footnoteParser) Parse(parent gast.Node, block text.Reader, pc parser.Co
 				d.Index = list.Count
 			}
 			index = d.Index
+			ref = d.Ref
 			break
 		}
 	}
@@ -164,7 +166,7 @@ func (s *footnoteParser) Parse(parent gast.Node, block text.Reader, pc parser.Co
 		return nil
 	}
 
-	return ast.NewFootnoteLink(index)
+	return ast.NewFootnoteLink(index, ref)
 }
 
 type footnoteASTTransformer struct {


### PR DESCRIPTION
Use user input as part of footnote identifier

Named footnotes (`[^foo]` instead of `[^42]`) use the name in HTML
node identifiers. This allows for stable references. Cool URLs don't
change.

Closes #92
