### PR TITLE
Insert space after task-list checkboxes

### DIFF
--- a/extension/_test/tasklist.txt
+++ b/extension/_test/tasklist.txt
@@ -4,8 +4,8 @@
 - [x] bar
 //- - - - - - - - -//
 <ul>
-<li><input disabled="" type="checkbox">foo</li>
-<li><input checked="" disabled="" type="checkbox">bar</li>
+<li><input disabled="" type="checkbox"> foo</li>
+<li><input checked="" disabled="" type="checkbox"> bar</li>
 </ul>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
 
@@ -19,12 +19,12 @@
 - [ ] bim
 //- - - - - - - - -//
 <ul>
-<li><input checked="" disabled="" type="checkbox">foo
+<li><input checked="" disabled="" type="checkbox"> foo
 <ul>
-<li><input disabled="" type="checkbox">bar</li>
-<li><input checked="" disabled="" type="checkbox">baz</li>
+<li><input disabled="" type="checkbox"> bar</li>
+<li><input checked="" disabled="" type="checkbox"> baz</li>
 </ul>
 </li>
-<li><input disabled="" type="checkbox">bim</li>
+<li><input disabled="" type="checkbox"> bim</li>
 </ul>
 //= = = = = = = = = = = = = = = = = = = = = = = =//

--- a/extension/tasklist.go
+++ b/extension/tasklist.go
@@ -92,9 +92,9 @@ func (r *TaskCheckBoxHTMLRenderer) renderTaskCheckBox(w util.BufWriter, source [
 		w.WriteString(`<input disabled="" type="checkbox"`)
 	}
 	if r.XHTML {
-		w.WriteString(" />")
+		w.WriteString(" /> ")
 	} else {
-		w.WriteString(">")
+		w.WriteString("> ")
 	}
 	return gast.WalkContinue, nil
 }


### PR DESCRIPTION
According to the [GFM spec](https://github.github.com/gfm/#task-list-items-extension-) (and per other implementations), a space
should be inserted after the checkbox input element. This gives visual
separation between the checkbox and its element. Update code and tests
to match.

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`

---- 

This brings goldmark into compliance with Pandoc's `markdown_github`, and the rendering on GitHub itself:

- [ ] Example.

Do let me know if there's an alternative way of adding this space that you'd prefer.

This should help with [`go-gitea/gitea#9656`](https://github.com/go-gitea/gitea/issues/9656).