### PR TITLE
Attribute unnecessary reread fix

### DIFF
--- a/parser/atx_heading.go
+++ b/parser/atx_heading.go
@@ -228,7 +228,7 @@ func parseLastLineAttributes(node ast.Node, reader text.Reader, pc Context) {
 			sl, start = lr.Position()
 			attrs, ok = ParseAttributes(lr)
 			_, end = lr.Position()
-			lr.SetPosition(sl, start)
+			lr.SetPosition(sl, end)
 		}
 		lr.Advance(1)
 	}


### PR DESCRIPTION
Seems like it rereads the whole attributes block beyond opening '{' even when it was a successful parse. I couldn't find any failing tests.