### PR TITLE
Fix possible memory confusion in unsafe slice cast

### DIFF
--- a/util/util_unsafe.go
+++ b/util/util_unsafe.go
@@ -4,6 +4,7 @@ package util
 
 import (
 	"reflect"
+	"runtime"
 	"unsafe"
 )
 
@@ -14,7 +15,12 @@ func BytesToReadOnlyString(b []byte) string {
 
 // StringToReadOnlyBytes returns bytes converted from given string.
 func StringToReadOnlyBytes(s string) []byte {
+	b := make([]byte, 0)
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := reflect.SliceHeader{Data: sh.Data, Len: sh.Len, Cap: sh.Len}
-	return *(*[]byte)(unsafe.Pointer(&bh))
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	bh.Data = sh.Data
+	bh.Cap = sh.Len
+	bh.Len = sh.Len
+	runtime.KeepAlive(s)
+	return b
 }

--- a/util/util_unsafe.go
+++ b/util/util_unsafe.go
@@ -4,7 +4,6 @@ package util
 
 import (
 	"reflect"
-	"runtime"
 	"unsafe"
 )
 
@@ -14,13 +13,11 @@ func BytesToReadOnlyString(b []byte) string {
 }
 
 // StringToReadOnlyBytes returns bytes converted from given string.
-func StringToReadOnlyBytes(s string) []byte {
-	b := make([]byte, 0)
+func StringToReadOnlyBytes(s string) (bs []byte) {
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&bs))
 	bh.Data = sh.Data
 	bh.Cap = sh.Len
 	bh.Len = sh.Len
-	runtime.KeepAlive(s)
-	return b
+	return
 }


### PR DESCRIPTION
I found an incorrect cast from `string` to `[]byte` in `util/util_unsafe.go`. The problem is that when `reflect.SliceHeader` is created as a composite literal (instead of deriving it from an actual slice by cast), then the Go garbage collector will not treat its `Data` field as a reference. If the GC runs just between creating the `SliceHeader` and casting it into the final, real `[]byte` slice, then the underlying data might have been collected already, effectively making the returned `[]byte` slice a dangling pointer.

This has a low probability to occur, but projects that import this library might still use it in a code path that gets executed a lot, thus increasing the probability to happen. Depending on the memory layout at the time of the GC run, this could potentially create an information leak vulnerability.

This PR changes the function to create the `reflect.SliceHeader` from an actual slice by first instantiating the return value.