### PR TITLE
Keep footnote backlinks with text

### DIFF
--- a/extension/_test/footnote.txt
+++ b/extension/_test/footnote.txt
@@ -12,7 +12,7 @@ That's some text with a footnote.[^1]
 <ol>
 <li id="fn:1" role="doc-endnote">
 <p>And that's the footnote.</p>
-<p>That's the second paragraph. <a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+<p>That's the second paragraph.&#160;<a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
 </li>
 </ol>
 </section>
@@ -37,13 +37,13 @@ This[^3] is[^1] text with footnotes[^2].
 <hr>
 <ol>
 <li id="fn:1" role="doc-endnote">
-<p>Footnote three <a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+<p>Footnote three&#160;<a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
 </li>
 <li id="fn:2" role="doc-endnote">
-<p>Footnote one <a href="#fnref:2" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+<p>Footnote one&#160;<a href="#fnref:2" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
 </li>
 <li id="fn:3" role="doc-endnote">
-<p>Footnote two <a href="#fnref:3" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+<p>Footnote two&#160;<a href="#fnref:3" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
 </li>
 </ol>
 </section>
@@ -61,7 +61,7 @@ test![^1]
 <hr>
 <ol>
 <li id="fn:1" role="doc-endnote">
-<p>footnote <a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+<p>footnote&#160;<a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
 </li>
 </ol>
 </section>

--- a/extension/footnote.go
+++ b/extension/footnote.go
@@ -258,7 +258,7 @@ func (r *FootnoteHTMLRenderer) renderFootnoteBackLink(w util.BufWriter, source [
 	if entering {
 		n := node.(*ast.FootnoteBackLink)
 		is := strconv.Itoa(n.Index)
-		_, _ = w.WriteString(` <a href="#fnref:`)
+		_, _ = w.WriteString(`&#160;<a href="#fnref:`)
 		_, _ = w.WriteString(is)
 		_, _ = w.WriteString(`" class="footnote-backref" role="doc-backlink">`)
 		_, _ = w.WriteString("&#x21a9;&#xfe0e;")


### PR DESCRIPTION
This inserts a non-breaking space before backlinks to prevent them from being separated from footnote text.

Results in the following when text wraps:

```
1. Roses are red, violets are
   blue ↩
```

Instead of this:

```
1. Roses are red, violets are blue
   ↩
```