### PR TITLE
Support URLs with port in Linkify

### DIFF
--- a/extension/_test/linkify.txt
+++ b/extension/_test/linkify.txt
@@ -161,3 +161,11 @@ https://nic.college
 //- - - - - - - - -//
 <p><a href="https://nic.college">https://nic.college</a></p>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
+
+
+17
+//- - - - - - - - -//
+http://server.intranet.acme.com:1313
+//- - - - - - - - -//
+<p><a href="http://server.intranet.acme.com:1313">http://server.intranet.acme.com:1313</a></p>
+//= = = = = = = = = = = = = = = = = = = = = = = =//

--- a/extension/linkify.go
+++ b/extension/linkify.go
@@ -11,9 +11,9 @@ import (
 	"github.com/yuin/goldmark/util"
 )
 
-var wwwURLRegxp = regexp.MustCompile(`^www\.[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]+(?:(?:/|[#?])[-a-zA-Z0-9@:%_\+.~#!?&//=\(\);,'">\^{}\[\]` + "`" + `]*)?`)
+var wwwURLRegxp = regexp.MustCompile(`^www\.[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]+(?:[/#?][-a-zA-Z0-9@:%_\+.~#!?&/=\(\);,'">\^{}\[\]` + "`" + `]*)?`)
 
-var urlRegexp = regexp.MustCompile(`^(?:http|https|ftp):\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]+(?:(?:/|[#?])[-a-zA-Z0-9@:%_+.~#$!?&//=\(\);,'">\^{}\[\]` + "`" + `]*)?`)
+var urlRegexp = regexp.MustCompile(`^(?:http|https|ftp)://[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]+(?::\d+)?(?:[/#?][-a-zA-Z0-9@:%_+.~#$!?&/=\(\);,'">\^{}\[\]` + "`" + `]*)?`)
 
 // An LinkifyConfig struct is a data structure that holds configuration of the
 // Linkify extension.


### PR DESCRIPTION
I propose to add support for URLs with port to Linkify extension. This is also supported in GFM and it's a very common use-case when writing internal documentation in many companies.