### PR TITLE
improve: create missing RendererFunc error message

### DIFF
--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -3,6 +3,7 @@ package renderer
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"sync"
 
@@ -161,6 +162,9 @@ func (r *renderer) Render(w io.Writer, source []byte, n ast.Node) error {
 	err := ast.Walk(n, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		s := ast.WalkStatus(ast.WalkContinue)
 		var err error
+		if len(r.nodeRendererFuncs) < int(n.Kind()) {
+			return s, fmt.Errorf("RendererFunc not found for kind: %s", n.Kind())
+		}
 		f := r.nodeRendererFuncs[n.Kind()]
 		if f != nil {
 			s, err = f(writer, source, n, entering)

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -1,0 +1,31 @@
+package renderer_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/renderer"
+)
+
+type customLink struct {
+	ast.Link
+}
+
+var kindCustomLink = ast.NewNodeKind("customLink")
+
+// Kind implements Node.Kind.
+func (n *customLink) Kind() ast.NodeKind {
+	return kindCustomLink
+}
+
+func TestMissingRendererFunc(t *testing.T) {
+	r := renderer.NewRenderer()
+	buf := bytes.NewBuffer([]byte{})
+
+	err := r.Render(buf, []byte{}, &customLink{})
+	if err.Error() != "RendererFunc not found for kind: customLink" {
+		t.Log(err)
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
Improve the development debugging process by better handling a
missing Node Kind RendererFunc. This:
```
panic: runtime error: index out of range [22] with length 20
```
Becomes:
```
panic: RendererFunc not found for kind: KindName
```