### PR TITLE
Remove unnecessary buffer

### DIFF
--- a/parser/link.go
+++ b/parser/link.go
@@ -293,20 +293,17 @@ func (s *linkParser) parseLink(parent ast.Node, last *linkLabelState, block text
 func parseLinkDestination(block text.Reader) ([]byte, bool) {
 	block.SkipSpaces()
 	line, _ := block.PeekLine()
-	buf := []byte{}
 	if block.Peek() == '<' {
 		i := 1
 		for i < len(line) {
 			c := line[i]
 			if c == '\\' && i < len(line)-1 && util.IsPunct(line[i+1]) {
-				buf = append(buf, '\\', line[i+1])
 				i += 2
 				continue
 			} else if c == '>' {
 				block.Advance(i + 1)
 				return line[1:i], true
 			}
-			buf = append(buf, c)
 			i++
 		}
 		return nil, false
@@ -316,7 +313,6 @@ func parseLinkDestination(block text.Reader) ([]byte, bool) {
 	for i < len(line) {
 		c := line[i]
 		if c == '\\' && i < len(line)-1 && util.IsPunct(line[i+1]) {
-			buf = append(buf, '\\', line[i+1])
 			i += 2
 			continue
 		} else if c == '(' {
@@ -329,7 +325,6 @@ func parseLinkDestination(block text.Reader) ([]byte, bool) {
 		} else if util.IsSpace(c) {
 			break
 		}
-		buf = append(buf, c)
 		i++
 	}
 	block.Advance(i)


### PR DESCRIPTION
Remove buf, which appears to be created and appended to but never used
for anything.  Found with staticcheck check SA4010 ("The result of
append will never be observed anywhere").