### PR TITLE
feat: Support named footnote reference links

### DIFF
--- a/extension/_test/footnote.txt
+++ b/extension/_test/footnote.txt
@@ -66,3 +66,26 @@ test![^1]
 </ol>
 </section>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
+6
+//- - - - - - - - -//
+test named[^named].
+
+test incorrect index number[^42]
+
+[^named]: footnote
+[^42]: footnote
+//- - - - - - - - -//
+<p>test named<sup id="fnref:named"><a href="#fn:named" class="footnote-ref" role="doc-noteref">named</a></sup>.</p>
+<p>test incorrect index number<sup id="fnref:2"><a href="#fn:2" class="footnote-ref" role="doc-noteref">2</a></sup></p>
+<section class="footnotes" role="doc-endnotes">
+<hr>
+<ol>
+<li id="fn:named" role="doc-endnote">
+<p>footnote <a href="#fnref:named" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+</li>
+<li id="fn:2" role="doc-endnote">
+<p>footnote <a href="#fnref:2" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+</li>
+</ol>
+</section>
+//= = = = = = = = = = = = = = = = = = = = = = = =//

--- a/extension/ast/footnote.go
+++ b/extension/ast/footnote.go
@@ -12,6 +12,7 @@ type FootnoteLink struct {
 	gast.BaseInline
 	Index    int
 	RefCount int
+	Ref      []byte
 }
 
 // Dump implements Node.Dump.
@@ -31,10 +32,11 @@ func (n *FootnoteLink) Kind() gast.NodeKind {
 }
 
 // NewFootnoteLink returns a new FootnoteLink node.
-func NewFootnoteLink(index int) *FootnoteLink {
+func NewFootnoteLink(index int, ref []byte) *FootnoteLink {
 	return &FootnoteLink{
 		Index:    index,
 		RefCount: 0,
+		Ref:      ref,
 	}
 }
 
@@ -44,6 +46,7 @@ type FootnoteBacklink struct {
 	gast.BaseInline
 	Index    int
 	RefCount int
+	Ref      []byte
 }
 
 // Dump implements Node.Dump.
@@ -63,10 +66,11 @@ func (n *FootnoteBacklink) Kind() gast.NodeKind {
 }
 
 // NewFootnoteBacklink returns a new FootnoteBacklink node.
-func NewFootnoteBacklink(index int) *FootnoteBacklink {
+func NewFootnoteBacklink(index int, ref []byte) *FootnoteBacklink {
 	return &FootnoteBacklink{
 		Index:    index,
 		RefCount: 0,
+		Ref:      ref,
 	}
 }
 


### PR DESCRIPTION
Uses the provided name for a PHP Markdown Extra Footnote reference when it is
not an incorrectly ordered number value, such as: `[^named]`. The reference names
were previously ignored and replaced with ordered index integers. According to:
https://michelf.ca/projects/php-markdown/extra/#footnotes

> Names can contain any character valid within an id attribute in HTML.