### PR TITLE
fix: panic on invalid NodeRenderer in renderer

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -734,7 +734,7 @@ func (p *parser) AddOptions(opts ...Option) {
 func (p *parser) addBlockParser(v util.PrioritizedValue, options map[OptionName]interface{}) {
 	bp, ok := v.Value.(BlockParser)
 	if !ok {
-		panic(fmt.Sprintf("%v is not a BlockParser", v.Value))
+		panic(fmt.Sprintf("%T is not a BlockParser", v.Value))
 	}
 	tcs := bp.Trigger()
 	so, ok := v.Value.(SetOptioner)
@@ -758,7 +758,7 @@ func (p *parser) addBlockParser(v util.PrioritizedValue, options map[OptionName]
 func (p *parser) addInlineParser(v util.PrioritizedValue, options map[OptionName]interface{}) {
 	ip, ok := v.Value.(InlineParser)
 	if !ok {
-		panic(fmt.Sprintf("%v is not a InlineParser", v.Value))
+		panic(fmt.Sprintf("%T is not a InlineParser", v.Value))
 	}
 	tcs := ip.Trigger()
 	so, ok := v.Value.(SetOptioner)
@@ -781,7 +781,7 @@ func (p *parser) addInlineParser(v util.PrioritizedValue, options map[OptionName
 func (p *parser) addParagraphTransformer(v util.PrioritizedValue, options map[OptionName]interface{}) {
 	pt, ok := v.Value.(ParagraphTransformer)
 	if !ok {
-		panic(fmt.Sprintf("%v is not a ParagraphTransformer", v.Value))
+		panic(fmt.Sprintf("%T is not a ParagraphTransformer", v.Value))
 	}
 	so, ok := v.Value.(SetOptioner)
 	if ok {
@@ -795,7 +795,7 @@ func (p *parser) addParagraphTransformer(v util.PrioritizedValue, options map[Op
 func (p *parser) addASTTransformer(v util.PrioritizedValue, options map[OptionName]interface{}) {
 	at, ok := v.Value.(ASTTransformer)
 	if !ok {
-		panic(fmt.Sprintf("%v is not a ASTTransformer", v.Value))
+		panic(fmt.Sprintf("%T is not a ASTTransformer", v.Value))
 	}
 	so, ok := v.Value.(SetOptioner)
 	if ok {

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -3,6 +3,7 @@ package renderer
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"sync"
 
@@ -139,7 +140,10 @@ func (r *renderer) Render(w io.Writer, source []byte, n ast.Node) error {
 		l := len(r.config.NodeRenderers)
 		for i := l - 1; i >= 0; i-- {
 			v := r.config.NodeRenderers[i]
-			nr, _ := v.Value.(NodeRenderer)
+			nr, ok := v.Value.(NodeRenderer)
+			if !ok {
+				panic(fmt.Errorf("%T is not a NodeRenderer", v.Value))
+			}
 			if se, ok := v.Value.(SetOptioner); ok {
 				for oname, ovalue := range r.options {
 					se.SetOption(oname, ovalue)

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -1,0 +1,28 @@
+package renderer_test
+
+import (
+	"testing"
+
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+type invalid struct{}
+
+func TestInvalidNodeRenderer(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("did not panic")
+			return
+		}
+
+		rerr := r.(error)
+		if rerr.Error() != "*renderer_test.invalid is not a NodeRenderer" {
+			t.Errorf("unexpected panic caught: %v", rerr)
+		}
+	}()
+
+	r := renderer.NewRenderer(renderer.WithNodeRenderers(util.Prioritized(&invalid{}, 1000)))
+	r.Render(nil, nil, nil)
+}


### PR DESCRIPTION
Uses the previously ignored type check ok value with a similar
structure to parse.go for the With* functional options.

Changes:
`runtime error: invalid memory address or nil pointer dereference`
to:
`<TypeName> is not a NodeRenderer`