### PR TITLE
Fix leading tabs with codeblocks

### DIFF
--- a/_test/extra.txt
+++ b/_test/extra.txt
@@ -159,3 +159,60 @@ bbb
 <img src="gt.jpg" alt="&gt;" />
 <img src="amp.jpg" alt="&amp;" /></p>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
+
+13: fenced code block starting with tab inside list
+//- - - - - - - - -//
+* foo
+  ```Makefile
+  foo
+  	foo
+  ```
+//- - - - - - - - -//
+<ul>
+<li>foo
+<pre><code class="language-Makefile">foo
+	foo
+</code></pre>
+</li>
+</ul>
+//= = = = = = = = = = = = = = = = = = = = = = = =//
+
+14: fenced code block inside list, mismatched tab start
+//- - - - - - - - -//
+* foo
+  ```Makefile
+  foo
+ 	foo
+  ```
+//- - - - - - - - -//
+<ul>
+<li>foo
+<pre><code class="language-Makefile">foo
+  foo
+</code></pre>
+</li>
+</ul>
+//= = = = = = = = = = = = = = = = = = = = = = = =//
+
+
+15: fenced code block inside nested list
+//- - - - - - - - -//
+* foo
+  -  bar
+     ```Makefile
+     foo
+     	foo
+     ```
+//- - - - - - - - -//
+<ul>
+<li>foo
+<ul>
+<li>bar
+<pre><code class="language-Makefile">foo
+	foo
+</code></pre>
+</li>
+</ul>
+</li>
+</ul>
+//= = = = = = = = = = = = = = = = = = = = = = = =//

--- a/extension/definition_list.go
+++ b/extension/definition_list.go
@@ -81,8 +81,8 @@ func (b *definitionListParser) Continue(node gast.Node, reader text.Reader, pc p
 	if w < list.Offset {
 		return parser.Close
 	}
-	pos, padding := util.IndentPosition(line, reader.LineOffset(), list.Offset)
-	reader.AdvanceAndSetPadding(pos, padding)
+	pos, padding, chars := util.IndentPosition(line, reader.LineOffset(), list.Offset)
+	reader.AdvanceAndSetPadding(pos, padding, chars)
 	return parser.Continue | parser.HasChildren
 }
 
@@ -137,8 +137,8 @@ func (b *definitionDescriptionParser) Open(parent gast.Node, reader text.Reader,
 		}
 		para.Parent().RemoveChild(para.Parent(), para)
 	}
-	cpos, padding := util.IndentPosition(line[pos+1:], pos+1, list.Offset-pos-1)
-	reader.AdvanceAndSetPadding(cpos, padding)
+	cpos, padding, chars := util.IndentPosition(line[pos+1:], pos+1, list.Offset-pos-1)
+	reader.AdvanceAndSetPadding(cpos, padding, chars)
 
 	return ast.NewDefinitionDescription(), parser.HasChildren
 }

--- a/extension/footnote.go
+++ b/extension/footnote.go
@@ -66,7 +66,7 @@ func (b *footnoteBlockParser) Open(parent gast.Node, reader text.Reader, pc pars
 		reader.Advance(pos)
 		return item, parser.NoChildren
 	}
-	reader.AdvanceAndSetPadding(pos, padding)
+	reader.AdvanceAndSetPadding(pos, padding, segment.PaddingChars)
 	return item, parser.HasChildren
 }
 
@@ -75,11 +75,11 @@ func (b *footnoteBlockParser) Continue(node gast.Node, reader text.Reader, pc pa
 	if util.IsBlank(line) {
 		return parser.Continue | parser.HasChildren
 	}
-	childpos, padding := util.IndentPosition(line, reader.LineOffset(), 4)
+	childpos, padding, paddingChars := util.IndentPosition(line, reader.LineOffset(), 4)
 	if childpos < 0 {
 		return parser.Close
 	}
-	reader.AdvanceAndSetPadding(childpos, padding)
+	reader.AdvanceAndSetPadding(childpos, padding, paddingChars)
 	return parser.Continue | parser.HasChildren
 }
 

--- a/parser/blockquote.go
+++ b/parser/blockquote.go
@@ -33,7 +33,7 @@ func (b *blockquoteParser) process(reader text.Reader) bool {
 	}
 	reader.Advance(pos)
 	if line[pos-1] == '\t' {
-		reader.SetPadding(2)
+		reader.SetPadding(2, []byte("  "))
 	}
 	return true
 }

--- a/parser/code_block.go
+++ b/parser/code_block.go
@@ -24,17 +24,18 @@ func (b *codeBlockParser) Trigger() []byte {
 
 func (b *codeBlockParser) Open(parent ast.Node, reader text.Reader, pc Context) (ast.Node, State) {
 	line, segment := reader.PeekLine()
-	pos, padding := util.IndentPosition(line, reader.LineOffset(), 4)
+	pos, padding, chars := util.IndentPosition(line, reader.LineOffset(), 4)
 	if pos < 0 || util.IsBlank(line) {
 		return nil, NoChildren
 	}
 	node := ast.NewCodeBlock()
-	reader.AdvanceAndSetPadding(pos, padding)
+
+
+	reader.AdvanceAndSetPadding(pos, padding, chars)
 	_, segment = reader.PeekLine()
-	node.Lines().Append(segment)
+	node.Lines().Append(segment.WithRenderPaddingTabs())
 	reader.Advance(segment.Len() - 1)
 	return node, NoChildren
-
 }
 
 func (b *codeBlockParser) Continue(node ast.Node, reader text.Reader, pc Context) State {
@@ -43,13 +44,13 @@ func (b *codeBlockParser) Continue(node ast.Node, reader text.Reader, pc Context
 		node.Lines().Append(segment.TrimLeftSpaceWidth(4, reader.Source()))
 		return Continue | NoChildren
 	}
-	pos, padding := util.IndentPosition(line, reader.LineOffset(), 4)
+	pos, padding, chars := util.IndentPosition(line, reader.LineOffset(), 4)
 	if pos < 0 {
 		return Close
 	}
-	reader.AdvanceAndSetPadding(pos, padding)
+	reader.AdvanceAndSetPadding(pos, padding, chars)
 	_, segment = reader.PeekLine()
-	node.Lines().Append(segment)
+	node.Lines().Append(segment.WithRenderPaddingTabs())
 	reader.Advance(segment.Len() - 1)
 	return Continue | NoChildren
 }

--- a/parser/fcode_block.go
+++ b/parser/fcode_block.go
@@ -70,6 +70,7 @@ func (b *fencedCodeBlockParser) Open(parent ast.Node, reader text.Reader, pc Con
 
 func (b *fencedCodeBlockParser) Continue(node ast.Node, reader text.Reader, pc Context) State {
 	line, segment := reader.PeekLine()
+
 	fdata := pc.Get(fencedCodeBlockInfoKey).(*fenceData)
 	w, pos := util.IndentWidth(line, reader.LineOffset())
 	if w < 4 {
@@ -86,11 +87,12 @@ func (b *fencedCodeBlockParser) Continue(node ast.Node, reader text.Reader, pc C
 			return Close
 		}
 	}
-	pos, padding := util.DedentPositionPadding(line, reader.LineOffset(), segment.Padding, fdata.indent)
 
-	seg := text.NewSegmentPadding(segment.Start+pos, segment.Stop, padding)
+	pos, padding, chars := util.DedentPositionPadding(line, reader.LineOffset(), segment.Padding, fdata.indent, segment.PaddingChars)
+	seg := text.NewSegmentPadding(segment.Start+pos, segment.Stop, padding, chars)
+	seg = seg.WithRenderPaddingTabs()
 	node.Lines().Append(seg)
-	reader.AdvanceAndSetPadding(segment.Stop-segment.Start-pos-1, padding)
+	reader.AdvanceAndSetPadding(segment.Stop-segment.Start-pos-1, padding, chars)
 	return Continue | NoChildren
 }
 

--- a/parser/list_item.go
+++ b/parser/list_item.go
@@ -44,9 +44,9 @@ func (b *listItemParser) Open(parent ast.Node, reader text.Reader, pc Context) (
 		return node, NoChildren
 	}
 
-	pos, padding := util.IndentPosition(line[match[4]:], match[4], itemOffset)
+	pos, padding, chars := util.IndentPosition(line[match[4]:], match[4], itemOffset)
 	child := match[3] + pos
-	reader.AdvanceAndSetPadding(child, padding)
+	reader.AdvanceAndSetPadding(child, padding, chars)
 	return node, HasChildren
 }
 
@@ -66,8 +66,8 @@ func (b *listItemParser) Continue(node ast.Node, reader text.Reader, pc Context)
 		}
 		return Close
 	}
-	pos, padding := util.IndentPosition(line, reader.LineOffset(), offset)
-	reader.AdvanceAndSetPadding(pos, padding)
+	pos, padding, paddingChars := util.IndentPosition(line, reader.LineOffset(), offset)
+	reader.AdvanceAndSetPadding(pos, padding, paddingChars)
 
 	return Continue | HasChildren
 }

--- a/util/util.go
+++ b/util/util.go
@@ -148,19 +148,36 @@ func TabWidth(currentPos int) int {
 //
 // width=2 is in the tab character. In this case, IndentPosition returns
 // (pos=1, padding=2)
-func IndentPosition(bs []byte, currentPos, width int) (pos, padding int) {
+func IndentPosition(bs []byte, currentPos, width int) (pos, padding int, paddingChars []byte) {
 	if width == 0 {
-		return 0, 0
+		return 0, 0, nil
 	}
 	w := 0
 	l := len(bs)
 	i := 0
 	hasTab := false
+
+	firstOver := true
+
 	for ; i < l; i++ {
+		if w > width && firstOver {
+			firstOver = false
+			for j := 0; j < w-width; j++ {
+				paddingChars = append(paddingChars, ' ')
+			}
+		}
 		if bs[i] == '\t' {
+			if w >= width {
+				firstOver = false
+				paddingChars = append(paddingChars, '\t')
+			}
 			w += TabWidth(currentPos + w)
 			hasTab = true
 		} else if bs[i] == ' ' {
+			if w >= width {
+				firstOver = false
+				paddingChars = append(paddingChars, ' ')
+			}
 			w++
 		} else {
 			break
@@ -168,85 +185,56 @@ func IndentPosition(bs []byte, currentPos, width int) (pos, padding int) {
 	}
 	if w >= width {
 		if !hasTab {
-			return width, 0
+			return width, 0, nil
 		}
-		return i, w - width
+		return i, w - width, paddingChars
 	}
-	return -1, -1
-}
-
-// IndentPositionPadding searches an indent position with the given width for the given line.
-// This function is mostly same as IndentPosition except this function
-// takes account into additional paddings.
-func IndentPositionPadding(bs []byte, currentPos, paddingv, width int) (pos, padding int) {
-	if width == 0 {
-		return 0, paddingv
-	}
-	w := 0
-	i := 0
-	l := len(bs)
-	for ; i < l; i++ {
-		if bs[i] == '\t' {
-			w += TabWidth(currentPos + w)
-		} else if bs[i] == ' ' {
-			w++
-		} else {
-			break
-		}
-	}
-	if w >= width {
-		return i - paddingv, w - width
-	}
-	return -1, -1
-}
-
-// DedentPosition dedents lines by the given width.
-func DedentPosition(bs []byte, currentPos, width int) (pos, padding int) {
-	if width == 0 {
-		return 0, 0
-	}
-	w := 0
-	l := len(bs)
-	i := 0
-	for ; i < l; i++ {
-		if bs[i] == '\t' {
-			w += TabWidth(currentPos + w)
-		} else if bs[i] == ' ' {
-			w++
-		} else {
-			break
-		}
-	}
-	if w >= width {
-		return i, w - width
-	}
-	return i, 0
+	return -1, -1, nil
 }
 
 // DedentPositionPadding dedents lines by the given width.
-// This function is mostly same as DedentPosition except this function
-// takes account into additional paddings.
-func DedentPositionPadding(bs []byte, currentPos, paddingv, width int) (pos, padding int) {
+// It takes account into additional paddings.
+func DedentPositionPadding(bs []byte, currentPos, paddingv, width int, origChars []byte) (pos, padding int, paddingChars []byte) {
 	if width == 0 {
-		return 0, paddingv
+		return 0, paddingv, origChars
 	}
 
 	w := 0
 	i := 0
 	l := len(bs)
+
+	firstOver := true
+
 	for ; i < l; i++ {
+		if w > width && firstOver {
+			firstOver = false
+			for j := 0; j < w-width; j++ {
+				paddingChars = append(paddingChars, ' ')
+			}
+		}
+
 		if bs[i] == '\t' {
+			if w >= width {
+				firstOver = false
+				paddingChars = append(paddingChars, '\t')
+			}
+
 			w += TabWidth(currentPos + w)
 		} else if bs[i] == ' ' {
+			if w >= width {
+				firstOver = false
+				paddingChars = append(paddingChars, ' ')
+			}
+
 			w++
 		} else {
 			break
 		}
 	}
 	if w >= width {
-		return i - paddingv, w - width
+		return i - paddingv, w - width, paddingChars
 	}
-	return i - paddingv, 0
+	return i - paddingv, 0, nil
 }
 
 // IndentWidth calculate an indent width for the given line.
@@ -265,23 +253,6 @@ func IndentWidth(bs []byte, currentPos int) (width, pos int) {
 		}
 	}
 	return
-}
-
-// FirstNonSpacePosition returns a position line that is a first nonspace
-// character.
-func FirstNonSpacePosition(bs []byte) int {
-	i := 0
-	for ; i < len(bs); i++ {
-		c := bs[i]
-		if c == ' ' || c == '\t' {
-			continue
-		}
-		if c == '\n' {
-			return -1
-		}
-		return i
-	}
-	return -1
 }
 
 // FindClosure returns a position that closes the given opener.
@@ -380,11 +351,6 @@ func TrimRight(source, b []byte) []byte {
 // TrimLeftLength returns a length of leading specified characters.
 func TrimLeftLength(source, s []byte) int {
 	return len(source) - len(TrimLeft(source, s))
-}
-
-// TrimRightLength returns a length of trailing specified characters.
-func TrimRightLength(source, s []byte) int {
-	return len(source) - len(TrimRight(source, s))
 }
 
 // TrimLeftSpaceLength returns a length of leading space characters.


### PR DESCRIPTION
Note that this is a breaking change and will require new goldmark major version.

I have tried to fix problem with leading tabs in fenced code blocks (and probably normal code blocks too).

Important note - tabs do not behave like "just 4 spaces". They "finish" 4 space columns. So tab can behave like anything between 1 space to 4 spaces, depending on position.

If you have MD like this (. represents space, [tb] , [t] or [] tabs)

```
*.some.text
..```
..foo
..[]foo
..```
```

you expect the tab to be kept in the code. This did not work properly in goldmark and I fixed that.

However, if you have a code like this

```
*.some.text
..```
..foo
.[t]foo
..```
```

what should happen? I decided that it should be two spaces, as the tab is not "completely" in the code block. Similarly, what should happen in this case

```
*.some.text
..```
..foo
.[t][tb]foo
..```
```

I decided that it should be first three spaces and then tab. Not sure what even is the correct solution here...

The crux of the fix is - text segments don't have just padding, but also remember what chars is the padding and then print that, if they are called to do so in the code blocks. In other cases, the paddingChars are ignored.

This should fix #177 .