### PR TITLE
Fix empty line detection in markdown in list

### DIFF
--- a/_test/extra.txt
+++ b/_test/extra.txt
@@ -235,3 +235,91 @@ bbb
 </li>
 </ul>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
+
+17: fenced code block in list, empty line, spaces on start
+//- - - - - - - - -//
+* foo
+  ```Makefile
+  foo
+  
+  foo
+  ```
+//- - - - - - - - -//
+<ul>
+<li>foo
+<pre><code class="language-Makefile">foo
+
+foo
+</code></pre>
+</li>
+</ul>
+//= = = = = = = = = = = = = = = = = = = = = = = =//
+
+18: fenced code block in list, empty line, no spaces on start
+//- - - - - - - - -//
+* foo
+  ```Makefile
+  foo
+
+  foo
+  ```
+//- - - - - - - - -//
+<ul>
+<li>foo
+<pre><code class="language-Makefile">foo
+
+foo
+</code></pre>
+</li>
+</ul>
+//= = = = = = = = = = = = = = = = = = = = = = = =//
+
+
+19: fenced code block inside nested list, empty line, spaces on start
+//- - - - - - - - -//
+* foo
+  -  bar
+     ```Makefile
+     foo
+
+     foo
+     ```
+//- - - - - - - - -//
+<ul>
+<li>foo
+<ul>
+<li>bar
+<pre><code class="language-Makefile">foo
+
+foo
+</code></pre>
+</li>
+</ul>
+</li>
+</ul>
+//= = = = = = = = = = = = = = = = = = = = = = = =//
+
+
+20: fenced code block inside nested list, empty line, no space on start
+//- - - - - - - - -//
+* foo
+  -  bar
+     ```Makefile
+     foo
+
+     foo
+     ```
+//- - - - - - - - -//
+<ul>
+<li>foo
+<ul>
+<li>bar
+<pre><code class="language-Makefile">foo
+
+foo
+</code></pre>
+</li>
+</ul>
+</li>
+</ul>
+//= = = = = = = = = = = = = = = = = = = = = = = =//

--- a/parser/list.go
+++ b/parser/list.go
@@ -164,6 +164,8 @@ func (b *listParser) Continue(node ast.Node, reader text.Reader, pc Context) Sta
 		if node.ChildCount() == 1 && node.LastChild().ChildCount() == 0 {
 			return Close
 		}
+
+		reader.Advance(len(line)-1)
 		return Continue | HasChildren
 	}
 

--- a/parser/list_item.go
+++ b/parser/list_item.go
@@ -53,6 +53,8 @@ func (b *listItemParser) Open(parent ast.Node, reader text.Reader, pc Context) (
 func (b *listItemParser) Continue(node ast.Node, reader text.Reader, pc Context) State {
 	line, _ := reader.PeekLine()
 	if util.IsBlank(line) {
+		reader.Advance(len(line)-1)
+
 		return Continue | HasChildren
 	}
 


### PR DESCRIPTION
Fix for independent issue in #177

The next parser should have the whitespace removed, even when it's blank