### PR TITLE
Add task class to tasklist items

### DIFF
--- a/extension/_test/tasklist.txt
+++ b/extension/_test/tasklist.txt
@@ -28,3 +28,18 @@
 <li class="task"><input disabled="" type="checkbox"> bim</li>
 </ul>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
+
+
+
+3
+//- - - - - - - - -//
+- [ ] foo
+- bar
+- [x] baz
+//- - - - - - - - -//
+<ul>
+<li class="task"><input disabled="" type="checkbox"> foo</li>
+<li>bar</li>
+<li class="task"><input checked="" disabled="" type="checkbox"> baz</li>
+</ul>
+//= = = = = = = = = = = = = = = = = = = = = = = =//

--- a/extension/_test/tasklist.txt
+++ b/extension/_test/tasklist.txt
@@ -4,8 +4,8 @@
 - [x] bar
 //- - - - - - - - -//
 <ul>
-<li><input disabled="" type="checkbox"> foo</li>
-<li><input checked="" disabled="" type="checkbox"> bar</li>
+<li class="task"><input disabled="" type="checkbox"> foo</li>
+<li class="task"><input checked="" disabled="" type="checkbox"> bar</li>
 </ul>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
 
@@ -19,12 +19,12 @@
 - [ ] bim
 //- - - - - - - - -//
 <ul>
-<li><input checked="" disabled="" type="checkbox"> foo
+<li class="task"><input checked="" disabled="" type="checkbox"> foo
 <ul>
-<li><input disabled="" type="checkbox"> bar</li>
-<li><input checked="" disabled="" type="checkbox"> baz</li>
+<li class="task"><input disabled="" type="checkbox"> bar</li>
+<li class="task"><input checked="" disabled="" type="checkbox"> baz</li>
 </ul>
 </li>
-<li><input disabled="" type="checkbox"> bim</li>
+<li class="task"><input disabled="" type="checkbox"> bim</li>
 </ul>
 //= = = = = = = = = = = = = = = = = = = = = = = =//

--- a/extension/tasklist.go
+++ b/extension/tasklist.go
@@ -40,7 +40,8 @@ func (s *taskCheckBoxParser) Parse(parent gast.Node, block text.Reader, pc parse
 		return nil
 	}
 
-	if _, ok := parent.Parent().(*gast.ListItem); !ok {
+	listItem, ok := parent.Parent().(*gast.ListItem)
+	if !ok {
 		return nil
 	}
 	line, _ := block.PeekLine()
@@ -48,6 +49,7 @@ func (s *taskCheckBoxParser) Parse(parent gast.Node, block text.Reader, pc parse
 	if m == nil {
 		return nil
 	}
+	listItem.SetAttributeString("class", []byte("task"))
 	value := line[m[2]:m[3]][0]
 	block.Advance(m[1])
 	checked := value == 'x' || value == 'X'


### PR DESCRIPTION
Currently, it is difficult to style tasklist items without broad `:has()` support (working draft [here](https://drafts.csswg.org/selectors-4/#relational)).

The tasklist extension takes the following markdown.
```
- [ ] foo
- bar
- [x] baz
```

The rendered HTML is as follows.
```
<ul>
<li><input disabled="" type="checkbox"> foo</li>
<li>bar</li>
<li><input checked="" disabled="" type="checkbox"> baz</li>
</ul>
```

In GitHub, we can see that the above markdown is rendered as follows.
- [ ] foo
- bar
- [x] baz

Matching GitHub's styling with the given goldmark rendering is quite difficult. As mentioned above, it would be trivial with broad support for `:has()` where we could target list items containing checkboxes (`li:has(input[type='checkbox']) {}`). Alternatively, we could use JavaScript. 

This PR adds `class="task"` to all tasklist items. This allows applying styling to tasklist items with a simple selector (`li.task {}`).