### PR TITLE
Keep backlinks with footnote text

### DIFF
--- a/extension/_test/footnote.txt
+++ b/extension/_test/footnote.txt
@@ -12,7 +12,7 @@ That's some text with a footnote.[^1]
 <ol>
 <li id="fn:1" role="doc-endnote">
 <p>And that's the footnote.</p>
-<p>That's the second paragraph. <a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+<p>That's the second paragraph.&#160;<a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
 </li>
 </ol>
 </section>
@@ -37,13 +37,13 @@ This[^3] is[^1] text with footnotes[^2].
 <hr>
 <ol>
 <li id="fn:1" role="doc-endnote">
-<p>Footnote three <a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+<p>Footnote three&#160;<a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
 </li>
 <li id="fn:2" role="doc-endnote">
-<p>Footnote one <a href="#fnref:2" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+<p>Footnote one&#160;<a href="#fnref:2" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
 </li>
 <li id="fn:3" role="doc-endnote">
-<p>Footnote two <a href="#fnref:3" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+<p>Footnote two&#160;<a href="#fnref:3" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
 </li>
 </ol>
 </section>
@@ -61,7 +61,7 @@ test![^1]
 <hr>
 <ol>
 <li id="fn:1" role="doc-endnote">
-<p>footnote <a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+<p>footnote&#160;<a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
 </li>
 </ol>
 </section>

--- a/extension/footnote.go
+++ b/extension/footnote.go
@@ -539,7 +539,7 @@ func (r *FootnoteHTMLRenderer) renderFootnoteBacklink(w util.BufWriter, source [
 	if entering {
 		n := node.(*ast.FootnoteBacklink)
 		is := strconv.Itoa(n.Index)
-		_, _ = w.WriteString(` <a href="#`)
+		_, _ = w.WriteString(`&#160;<a href="#`)
 		_, _ = w.Write(r.idPrefix(node))
 		_, _ = w.WriteString(`fnref:`)
 		_, _ = w.WriteString(is)

--- a/extension/footnote_test.go
+++ b/extension/footnote_test.go
@@ -69,10 +69,10 @@ Another one.[^2]
 <hr>
 <ol>
 <li id="article12-fn:1" role="doc-endnote">
-<p>And that's the footnote. <a href="#article12-fnref:1" class="backlink-class" title="backlink-title" role="doc-backlink">^</a></p>
+<p>And that's the footnote.&#160;<a href="#article12-fnref:1" class="backlink-class" title="backlink-title" role="doc-backlink">^</a></p>
 </li>
 <li id="article12-fn:2" role="doc-endnote">
-<p>Another footnote. <a href="#article12-fnref:2" class="backlink-class" title="backlink-title" role="doc-backlink">^</a></p>
+<p>Another footnote.&#160;<a href="#article12-fnref:2" class="backlink-class" title="backlink-title" role="doc-backlink">^</a></p>
 </li>
 </ol>
 </section>
@@ -129,10 +129,10 @@ Another one.[^2]
 <hr>
 <ol>
 <li id="article12-fn:1" role="doc-endnote">
-<p>And that's the footnote. <a href="#article12-fnref:1" class="backlink-class" title="backlink-title" role="doc-backlink">^</a></p>
+<p>And that's the footnote.&#160;<a href="#article12-fnref:1" class="backlink-class" title="backlink-title" role="doc-backlink">^</a></p>
 </li>
 <li id="article12-fn:2" role="doc-endnote">
-<p>Another footnote. <a href="#article12-fnref:2" class="backlink-class" title="backlink-title" role="doc-backlink">^</a></p>
+<p>Another footnote.&#160;<a href="#article12-fnref:2" class="backlink-class" title="backlink-title" role="doc-backlink">^</a></p>
 </li>
 </ol>
 </section>


### PR DESCRIPTION
Fixes #196. Inserts a non-breaking space before backlinks to prevent them from being separated from footnote text.