### PR TITLE
Fix logic for soft line breaks

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1129,21 +1129,27 @@ func (p *parser) parseBlock(block text.BlockReader, parent ast.Node, pc Context)
 			break
 		}
 		lineLength := len(line)
+		softLinebreak := false
 		hardlineBreak := false
-		softLinebreak := line[lineLength-1] == '\n'
-		if lineLength >= 2 && line[lineLength-2] == '\\' && softLinebreak { // ends with \\n
+		hasNewLine := line[lineLength-1] == '\n'
+		if lineLength >= 2 && line[lineLength-2] == '\\' && hasNewLine { // ends with \\n
 			lineLength -= 2
 			hardlineBreak = true
 
-		} else if lineLength >= 3 && line[lineLength-3] == '\\' && line[lineLength-2] == '\r' && softLinebreak { // ends with \\r\n
+		} else if lineLength >= 3 && line[lineLength-3] == '\\' && line[lineLength-2] == '\r' && hasNewLine { // ends with \\r\n
 			lineLength -= 3
 			hardlineBreak = true
-		} else if lineLength >= 3 && line[lineLength-3] == ' ' && line[lineLength-2] == ' ' && softLinebreak { // ends with [space][space]\n
+		} else if lineLength >= 3 && line[lineLength-3] == ' ' && line[lineLength-2] == ' ' && hasNewLine { // ends with [space][space]\n
 			lineLength -= 3
 			hardlineBreak = true
-		} else if lineLength >= 4 && line[lineLength-4] == ' ' && line[lineLength-3] == ' ' && line[lineLength-2] == '\r' && softLinebreak { // ends with [space][space]\r\n
+		} else if lineLength >= 4 && line[lineLength-4] == ' ' && line[lineLength-3] == ' ' && line[lineLength-2] == '\r' && hasNewLine { // ends with [space][space]\r\n
 			lineLength -= 4
 			hardlineBreak = true
+		} else if hasNewLine {
+			// If the line ends with a newline character, but it is not a hardlineBreak, then it is a softLinebreak
+			// If the line ends with a hardlineBreak, then it cannot end with a softLinebreak
+			// See https://spec.commonmark.org/0.29/#soft-line-breaks
+			softLinebreak = true
 		}
 
 		l, startPosition := block.Position()


### PR DESCRIPTION
According to [the spec](https://spec.commonmark.org/0.29/#soft-line-breaks):

> A regular line break (not in a code span or HTML tag) **that is not preceded by two or more spaces or a backslash** is parsed as a softbreak.

The previous logic marked any line that ended with a line break as a soft break, so I have made changes to follow the spec.

All the tests still pass, and now the use of `n.SoftLineBreak()` is now consistent with the spec.