### PR TITLE
renderer: fix panic on unregistered node kind

### DIFF
--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -160,6 +160,9 @@ func (r *renderer) Render(w io.Writer, source []byte, n ast.Node) error {
 	}
 	err := ast.Walk(n, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		s := ast.WalkStatus(ast.WalkContinue)
+		if n.Kind() > r.maxKind {
+			return s, nil
+		}
 		var err error
 		f := r.nodeRendererFuncs[n.Kind()]
 		if f != nil {


### PR DESCRIPTION
Renderers can ignore nodes they aren't interested in. However when a
renderer doesn't register the highest node kind traversing a Markdown
document results in the following panic:

    panic: runtime error: index out of range [1] with length 1

    goroutine 1 [running]:
    github.com/yuin/goldmark/renderer.(*renderer).Render.func2({0x9d8630, 0xc0001237a0}, 0x40?)
    	/home/simon/go/pkg/mod/github.com/yuin/goldmark@v1.4.11/renderer/renderer.go:164 +0xd9
    github.com/yuin/goldmark/ast.walkHelper({0x9d8630, 0xc0001237a0}, 0xc000521a48)
    	/home/simon/go/pkg/mod/github.com/yuin/goldmark@v1.4.11/ast/ast.go:492 +0x34
    github.com/yuin/goldmark/ast.Walk(...)
    	/home/simon/go/pkg/mod/github.com/yuin/goldmark@v1.4.11/ast/ast.go:487
    github.com/yuin/goldmark/renderer.(*renderer).Render(0xc0002d80a0?, {0x9d3b60?, 0xc0000744a0?}, {0xc0002f4580?, 0x281?, 0x2c0?}, {0x9d8630?, 0xc0001237a0?})
    	/home/simon/go/pkg/mod/github.com/yuin/goldmark@v1.4.11/renderer/renderer.go:161 +0x225
    github.com/yuin/goldmark.(*markdown).Convert(0xc0001e1d40, {0xc0002f4580, 0x281, 0x2c0}, {0x9d3b60, 0xc0000744a0}, {0x0, 0x0, 0x0})
    	/home/simon/go/pkg/mod/github.com/yuin/goldmark@v1.4.11/markdown.go:117 +0x10b
    main.renderMarkdown({0xc0002f42c0, 0x281})
    	/home/simon/src/hut/markdown.go:16 +0x97
    main.newListsListCommand.func1(0xc000270280?, {0xc778b8, 0x0, 0x0?})
    	/home/simon/src/hut/lists.go:109 +0x2ee
    github.com/spf13/cobra.(*Command).execute(0xc000270280, {0xc778b8, 0x0, 0x0})
    	/home/simon/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:860 +0x663
    github.com/spf13/cobra.(*Command).ExecuteC(0xc000242c80)
    	/home/simon/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:974 +0x3b4
    github.com/spf13/cobra.(*Command).Execute(...)
    	/home/simon/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:902
    github.com/spf13/cobra.(*Command).ExecuteContext(...)
    	/home/simon/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:895
    main.main()
    	/home/simon/src/hut/main.go:49 +0x30b

Make sure r.nodeRendererFuncs is large enough before trying to access it.

Workaround without this patch:

```go
reg.Register(ast.NodeKind(128), nil)
```