### PR TITLE
Remove unnecessary nil check

### DIFF
--- a/extension/linkify.go
+++ b/extension/linkify.go
@@ -252,7 +252,7 @@ func (s *linkifyParser) Parse(parent ast.Node, block text.Reader, pc parser.Cont
 		}
 		at := bytes.IndexByte(line, '@')
 		m = []int{0, stop, at, stop - 1}
-		if m == nil || bytes.IndexByte(line[m[2]:m[3]], '.') < 0 {
+		if bytes.IndexByte(line[m[2]:m[3]], '.') < 0 {
 			return nil
 		}
 		lastChar := line[m[1]-1]


### PR DESCRIPTION
`m` is never `nil` because it is initialized at the previous line with slice.