### PR TITLE
extension/table.go: celss typo

### DIFF
--- a/extension/table.go
+++ b/extension/table.go
@@ -48,7 +48,7 @@ const (
 type TableConfig struct {
 	html.Config
 
-	// TableCellAlignMethod indicates how are table celss aligned.
+	// TableCellAlignMethod indicates how table cells are aligned.
 	TableCellAlignMethod TableCellAlignMethod
 }
 


### PR DESCRIPTION
Noticed a minor typo while reading the code. Cheers