### PR TITLE
testutil: Export ParseTestCaseFile

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -236,7 +236,8 @@ func ParseTestCaseFile(filename string) ([]MarkdownTestCase, error) {
 func DoTestCaseFile(m goldmark.Markdown, filename string, t TestingT, no ...int) {
 	allCases, err := ParseTestCaseFile(filename)
 	if err != nil {
-		panic(err)
+		t.Errorf("%v: %v", filename, err)
+		t.FailNow()
 	}
 
 	cases := allCases[:0]

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -3,7 +3,6 @@ package testutil
 import (
 	"errors"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -13,7 +12,7 @@ import (
 // that doesn't conform to testing.T.
 var _ TestingT = (*testing.T)(nil)
 
-func TestParseTestCaseFile(t *testing.T) {
+func TestParseTestCases(t *testing.T) {
 	tests := []struct {
 		desc string
 		give string // contents of the test file
@@ -85,12 +84,7 @@ func TestParseTestCaseFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			filename := filepath.Join(t.TempDir(), "give.txt")
-			if err := os.WriteFile(filename, []byte(tt.give), 0o644); err != nil {
-				t.Fatal(err)
-			}
-
-			got, err := ParseTestCaseFile(filename)
+			got, err := ParseTestCases(strings.NewReader(tt.give))
 			if err != nil {
 				t.Fatalf("could not parse: %v", err)
 			}
@@ -104,7 +98,7 @@ func TestParseTestCaseFile(t *testing.T) {
 	}
 }
 
-func TestParseTestCaseFile_Errors(t *testing.T) {
+func TestParseTestCases_Errors(t *testing.T) {
 	tests := []struct {
 		desc   string
 		give   string // contents of the test file
@@ -166,12 +160,7 @@ func TestParseTestCaseFile_Errors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			filename := filepath.Join(t.TempDir(), "give.txt")
-			if err := os.WriteFile(filename, []byte(tt.give), 0o644); err != nil {
-				t.Fatal(err)
-			}
-
-			cases, err := ParseTestCaseFile(filename)
+			cases, err := ParseTestCases(strings.NewReader(tt.give))
 			if err == nil {
 				t.Fatalf("expected error, got:\n%#v", cases)
 			}
@@ -182,6 +171,18 @@ func TestParseTestCaseFile_Errors(t *testing.T) {
 				t.Errorf("does not contain = %v", tt.errMsg)
 			}
 		})
+	}
+}
+
+func TestParseTestCaseFile_Error(t *testing.T) {
+	cases, err := ParseTestCaseFile("does_not_exist.txt")
+	if err == nil {
+		t.Fatalf("expected error, got:\n%#v", cases)
+	}
+
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("  unexpected error = %v", err)
+		t.Errorf("expected unwrap to = %v", os.ErrNotExist)
 	}
 }
 

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -1,7 +1,104 @@
 package testutil
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
 
 // This will fail to compile if the TestingT interface is changed in a way
 // that doesn't conform to testing.T.
 var _ TestingT = (*testing.T)(nil)
+
+func TestParseTestCaseFile(t *testing.T) {
+	tests := []struct {
+		desc string
+		give string // contents of the test file
+		want []MarkdownTestCase
+	}{
+		{
+			desc: "empty",
+			give: "",
+			want: []MarkdownTestCase{},
+		},
+		{
+			desc: "simple",
+			give: strings.Join([]string{
+				"1",
+				"//- - - - - - - - -//",
+				"input",
+				"//- - - - - - - - -//",
+				"output",
+				"//= = = = = = = = = = = = = = = = = = = = = = = =//",
+			}, "\n"),
+			want: []MarkdownTestCase{
+				{
+					No:       1,
+					Markdown: "input",
+					Expected: "output\n",
+				},
+			},
+		},
+		{
+			desc: "description",
+			give: strings.Join([]string{
+				"2:check something",
+				"//- - - - - - - - -//",
+				"hello",
+				"//- - - - - - - - -//",
+				"<p>hello</p>",
+				"//= = = = = = = = = = = = = = = = = = = = = = = =//",
+			}, "\n"),
+			want: []MarkdownTestCase{
+				{
+					No:          2,
+					Description: "check something",
+					Markdown:    "hello",
+					Expected:    "<p>hello</p>\n",
+				},
+			},
+		},
+		{
+			desc: "options",
+			give: strings.Join([]string{
+				"3",
+				`OPTIONS: {"trim": true}`,
+				"//- - - - - - - - -//",
+				"world",
+				"//- - - - - - - - -//",
+				"<p>world</p>",
+				"//= = = = = = = = = = = = = = = = = = = = = = = =//",
+			}, "\n"),
+			want: []MarkdownTestCase{
+				{
+					No:       3,
+					Options:  MarkdownTestCaseOptions{Trim: true},
+					Markdown: "world",
+					Expected: "<p>world</p>\n",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			filename := filepath.Join(t.TempDir(), "give.txt")
+			if err := os.WriteFile(filename, []byte(tt.give), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := ParseTestCaseFile(filename)
+			if err != nil {
+				t.Fatalf("could not parse: %v", err)
+			}
+
+			if !reflect.DeepEqual(tt.want, got) {
+				t.Errorf("output did not match:")
+				t.Errorf(" got = %#v", got)
+				t.Errorf("want = %#v", tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR extracts functionality from DoTestCaseFile 
responsible for parsing test case files
into a ParseTestCases function.

The function is able to read from any io.Reader,
instead of being limited to just files.
A ParseTestCaseFile function is included for convenience.

The functions do not panic on errors--instead, they return the error.

While there, this updates DoTestCaseFile
so that it also does not panic on error,
and instead aborts the entire test instead.

Minor note about tests:
The tests for the parser use `reflect.DeepEqual` and `%#v`.
It would make for better error messages to use [go-cmp](https://github.com/google/go-cmp)
but I elected to not use that because so far,
goldmark has no third-party dependencies.
If you're open to the new dependency (only for test util),
I can make a separate PR for that in the future.