### PR TITLE
extra_test.go: Add test timeout multiplier environment variable

### DIFF
--- a/extra_test.go
+++ b/extra_test.go
@@ -2,6 +2,8 @@ package goldmark_test
 
 import (
 	"bytes"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +14,15 @@ import (
 	"github.com/yuin/goldmark/renderer/html"
 	"github.com/yuin/goldmark/testutil"
 )
+
+var testTimeoutMultiplier = 1.0
+
+func init() {
+	m, err := strconv.ParseFloat(os.Getenv("GOLDMARK_TEST_TIMEOUT_MULTIPLIER"), 64)
+	if err == nil {
+		testTimeoutMultiplier = m
+	}
+}
 
 func TestExtras(t *testing.T) {
 	markdown := New(WithRendererOptions(
@@ -108,8 +119,8 @@ func TestDeepNestedLabelPerformance(t *testing.T) {
 	var b bytes.Buffer
 	_ = markdown.Convert(source, &b)
 	finished := nowMillis()
-	if (finished - started) > 5000 {
-		t.Error("Parsing deep nested labels took more 5 secs")
+	if (finished - started) > int64(5000*testTimeoutMultiplier) {
+		t.Error("Parsing deep nested labels took too long")
 	}
 }
 
@@ -128,8 +139,8 @@ func TestManyProcessingInstructionPerformance(t *testing.T) {
 	var b bytes.Buffer
 	_ = markdown.Convert(source, &b)
 	finished := nowMillis()
-	if (finished - started) > 5000 {
-		t.Error("Parsing processing instructions took more 5 secs")
+	if (finished - started) > int64(5000*testTimeoutMultiplier) {
+		t.Error("Parsing processing instructions took too long")
 	}
 }
 
@@ -148,8 +159,8 @@ func TestManyCDATAPerformance(t *testing.T) {
 	var b bytes.Buffer
 	_ = markdown.Convert(source, &b)
 	finished := nowMillis()
-	if (finished - started) > 5000 {
-		t.Error("Parsing processing instructions took more 5 secs")
+	if (finished - started) > int64(5000*testTimeoutMultiplier) {
+		t.Error("Parsing processing instructions took too long")
 	}
 }
 
@@ -168,8 +179,8 @@ func TestManyDeclPerformance(t *testing.T) {
 	var b bytes.Buffer
 	_ = markdown.Convert(source, &b)
 	finished := nowMillis()
-	if (finished - started) > 5000 {
-		t.Error("Parsing processing instructions took more 5 secs")
+	if (finished - started) > int64(5000*testTimeoutMultiplier) {
+		t.Error("Parsing processing instructions took too long")
 	}
 }
 
@@ -188,7 +199,7 @@ func TestManyCommentPerformance(t *testing.T) {
 	var b bytes.Buffer
 	_ = markdown.Convert(source, &b)
 	finished := nowMillis()
-	if (finished - started) > 5000 {
-		t.Error("Parsing processing instructions took more 5 secs")
+	if (finished - started) > int64(5000*testTimeoutMultiplier) {
+		t.Error("Parsing processing instructions took too long")
 	}
 }


### PR DESCRIPTION
Hi,

Currently some performance tests in `extra_test.go` are failing in low-performance environments (QEMU user mode emulation in my case).

```
=== RUN   TestDeepNestedLabelPerformance
    extra_test.go:112: Parsing deep nested labels took more 5 secs
--- FAIL: TestDeepNestedLabelPerformance (25.33s)
=== RUN   TestManyProcessingInstructionPerformance
    extra_test.go:132: Parsing processing instructions took more 5 secs
--- FAIL: TestManyProcessingInstructionPerformance (14.11s)
=== RUN   TestManyCDATAPerformance
    extra_test.go:152: Parsing processing instructions took more 5 secs
--- FAIL: TestManyCDATAPerformance (33.70s)
=== RUN   TestManyDeclPerformance
    extra_test.go:172: Parsing processing instructions took more 5 secs
--- FAIL: TestManyDeclPerformance (16.28s)
=== RUN   TestManyCommentPerformance
    extra_test.go:192: Parsing processing instructions took more 5 secs
--- FAIL: TestManyCommentPerformance (40.88s)
```

I think reading a timeout multiplier from environment variable is a reasonable way to test goldmark in those low-performance environments without affecting the tests in normal environments.

Thank you for looking into this PR!