### PR TITLE
Fix #335

### DIFF
--- a/extension/linkify.go
+++ b/extension/linkify.go
@@ -277,7 +277,7 @@ func (s *linkifyParser) Parse(parent ast.Node, block text.Reader, pc parser.Cont
 	for ; i > 0; i-- {
 		c := line[i]
 		switch c {
-		case '?', '!', '.', ',', ':', '*', '_', '~':
+		case '?', '!', '.', ',', ':', '*', '_', '~', '\'', '"':
 		default:
 			goto endfor
 		}

--- a/extension/linkify_test.go
+++ b/extension/linkify_test.go
@@ -21,6 +21,28 @@ func TestLinkify(t *testing.T) {
 	testutil.DoTestCaseFile(markdown, "_test/linkify.txt", t, testutil.ParseCliCaseArg()...)
 }
 
+func TestLinkifyWithTypographer(t *testing.T) {
+	markdown := goldmark.New(
+		goldmark.WithRendererOptions(
+			html.WithUnsafe(),
+		),
+		goldmark.WithExtensions(
+			Linkify,
+			Typographer,
+		),
+	)
+
+	testutil.DoTestCase(
+		markdown,
+		testutil.MarkdownTestCase{
+			No:       1,
+			Markdown: `'http://example.com/' "http://example.com/"`,
+			Expected: `<p>&lsquo;<a href="http://example.com/">http://example.com/</a>&rsquo; &ldquo;<a href="http://example.com/">http://example.com/</a>&rdquo;</p>`,
+		},
+		t,
+	)
+}
+
 func TestLinkifyWithAllowedProtocols(t *testing.T) {
 	markdown := goldmark.New(
 		goldmark.WithRendererOptions(


### PR DESCRIPTION
I think this fixes the issue described in #335 when using both linkify and typographer. I intend my contribution to be similar to the behaviour of https://github.com/github/cmark-gfm/blob/6a6e335709ef68cf2c616eeaf61b09ed4c654669/extensions/autolink.c#L58

However, when using just linkify, it doesn't trigger on quotes so there will be no link created. This seems inconsistent to me but it was not part of the original issue so I'm just mentioning it.