### PR TITLE
Adding two extensions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,8 @@ Extensions
 - [goldmark-embed](https://github.com/13rac1/goldmark-embed): Adds support for rendering embeds from YouTube links.
 - [goldmark-latex](https://github.com/soypat/goldmark-latex): A $\LaTeX$ renderer that can be passed to `goldmark.WithRenderer()`.
 - [goldmark-fences](https://github.com/stefanfritsch/goldmark-fences): Support for pandoc-style [fenced divs](https://pandoc.org/MANUAL.html#divs-and-spans) in goldmark.
+- [goldmark-d2](https://github.com/FurqanSoftware/goldmark-d2): Adds support for [D2](https://d2lang.com/) diagrams.
+- [goldmark-katex](https://github.com/FurqanSoftware/goldmark-katex): Adds support for [KaTeX](https://katex.org/) math and equations.
 
 
 goldmark internal(for extension developers)


### PR DESCRIPTION
This PR adds two extensions to the list of extensions in README.md:

- [goldmark-d2](https://github.com/FurqanSoftware/goldmark-d2): This adds support for diagrams using D2. D2 is a declarative language where you can generate SVG diagrams from textual descriptions.
- [goldmark-katex](https://github.com/FurqanSoftware/goldmark-katex): This adds support for math and equations (both inline and block) using the well-known KaTeX library.
