### PR TITLE
fuzz: Make goldmark compatible with OSS-Fuzz

### DIFF
--- a/_tools/build-oss-fuzz-corpus.go
+++ b/_tools/build-oss-fuzz-corpus.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type TestCase struct {
+	Example  int    `json:"example"`
+	Markdown string `json:"markdown"`
+}
+
+func main() {
+	corpus_out := os.Args[1]
+	if !strings.HasSuffix(corpus_out, ".zip") {
+		log.Fatalln("Expected command line:", os.Args[0], "<corpus_output>.zip")
+	}
+
+	zip_file, err := os.Create(corpus_out)
+
+	zip_writer := zip.NewWriter(zip_file)
+
+	if err != nil {
+		log.Fatalln("Failed creating file:", err)
+	}
+
+	json_corpus := "_test/spec.json"
+	bs, err := ioutil.ReadFile(json_corpus)
+	if err != nil {
+		log.Fatalln("Could not open file:", json_corpus)
+		panic(err)
+	}
+	var testCases []TestCase
+	if err := json.Unmarshal(bs, &testCases); err != nil {
+		panic(err)
+	}
+
+	for _, c := range testCases {
+		file_in_zip := "example-" + strconv.Itoa(c.Example)
+		f, err := zip_writer.Create(file_in_zip)
+		if err != nil {
+			log.Fatal(err)
+		}
+		_, err = f.Write([]byte(c.Markdown))
+		if err != nil {
+			log.Fatalf("Failed to write file: %s into zip file", file_in_zip)
+		}
+	}
+
+	err = zip_writer.Close()
+	if err != nil {
+		log.Fatal("Failed to close zip writer", err)
+	}
+
+	zip_file.Close()
+}

--- a/fuzz/fuzz_test.go
+++ b/fuzz/fuzz_test.go
@@ -13,19 +13,7 @@ import (
 	"github.com/yuin/goldmark/util"
 )
 
-func Fuzz(f *testing.F) {
-	bs, err := ioutil.ReadFile("../_test/spec.json")
-	if err != nil {
-		panic(err)
-	}
-	var testCases []map[string]interface{}
-	if err := json.Unmarshal(bs, &testCases); err != nil {
-		panic(err)
-	}
-	for _, c := range testCases {
-		f.Add(c["markdown"])
-	}
-
+func fuzz(f *testing.F) {
 	f.Fuzz(func(t *testing.T, orig string) {
 		markdown := goldmark.New(
 			goldmark.WithParserOptions(
@@ -51,4 +39,19 @@ func Fuzz(f *testing.F) {
 			panic(err)
 		}
 	})
+}
+
+func FuzzDefault(f *testing.F) {
+	bs, err := ioutil.ReadFile("../_test/spec.json")
+	if err != nil {
+		panic(err)
+	}
+	var testCases []map[string]interface{}
+	if err := json.Unmarshal(bs, &testCases); err != nil {
+		panic(err)
+	}
+	for _, c := range testCases {
+		f.Add(c["markdown"])
+	}
+	fuzz(f)
 }

--- a/fuzz/oss_fuzz_test.go
+++ b/fuzz/oss_fuzz_test.go
@@ -1,0 +1,9 @@
+package fuzz
+
+import (
+	"testing"
+)
+
+func FuzzOss(f *testing.F) {
+	fuzz(f)
+}


### PR DESCRIPTION
This set of changes will make goldmark compatible with the fuzzing requirements for google/oss-fuzz, a continuous fuzzing service. To ensure compatibility this change adds;
- A seperate fuzzing target that doesn't use the builtin fuzz corpus
- A tool to convert the builtin fuzz corpus to a zip file corpus that is compatible with oss-fuzz