### PR TITLE
Update README.md - add extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Extensions
 - [goldmark-fences](https://github.com/stefanfritsch/goldmark-fences): Support for pandoc-style [fenced divs](https://pandoc.org/MANUAL.html#divs-and-spans) in goldmark.
 - [goldmark-d2](https://github.com/FurqanSoftware/goldmark-d2): Adds support for [D2](https://d2lang.com/) diagrams.
 - [goldmark-katex](https://github.com/FurqanSoftware/goldmark-katex): Adds support for [KaTeX](https://katex.org/) math and equations.
+- [goldmark-img64](https://github.com/tenkoh/goldmark-img64): Adds support for embedding images into the document as DataURL (base64 encoded).
 
 
 goldmark internal(for extension developers)


### PR DESCRIPTION
Add extension `goldmark-img64` to support embedding images as DataURL.