### PR TITLE
add comments about errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Convert Markdown documents with the CommonMark-compliant mode:
 ```go
 var buf bytes.Buffer
 if err := goldmark.Convert(source, &buf); err != nil {
-  panic(err)
+  panic(err) // errors won't occur with in-memory buffer and default html renderers
 }
 ```
 

--- a/markdown.go
+++ b/markdown.go
@@ -27,6 +27,7 @@ var defaultMarkdown = New()
 
 // Convert interprets a UTF-8 bytes source in Markdown and
 // write rendered contents to a writer w.
+// Errors are reported as per the Writer interface and provided renderers.
 func Convert(source []byte, w io.Writer, opts ...parser.ParseOption) error {
 	return defaultMarkdown.Convert(source, w, opts...)
 }
@@ -36,6 +37,7 @@ func Convert(source []byte, w io.Writer, opts ...parser.ParseOption) error {
 type Markdown interface {
 	// Convert interprets a UTF-8 bytes source in Markdown and write rendered
 	// contents to a writer w.
+	// Errors are reported as per the Writer interface and provided renderers.
 	Convert(source []byte, writer io.Writer, opts ...parser.ParseOption) error
 
 	// Parser returns a Parser that will be used for conversion.


### PR DESCRIPTION
Hi, thanks for your valuable work!

I've spent some time guessing why `Convert` method returns errors. My first guess was that the parser returns an error whenever it's unable to parse the input (which is strange). It turned out that the only possible cases for errors are:
1) Provided `Writer` implementation returns an error
2) User-custom html renderers returns an error 

So, in the default scenario there won't be any errors.

I've just highlighted these cases in the comments, so that future developers wouldn't have to spend time for guesswork.