### PR TITLE
Add support for CJK Symbols and Punctuation

### DIFF
--- a/extension/cjk_test.go
+++ b/extension/cjk_test.go
@@ -197,4 +197,15 @@ func TestEastAsianLineBreaks(t *testing.T) {
 		},
 		t,
 	)
+	no = 8
+	testutil.DoTestCase(
+		markdown,
+		testutil.MarkdownTestCase{
+			No:          no,
+			Description: "Soft line breaks between east asian wide characters or punctuations are ignored",
+			Markdown:    "太郎は\\ **「こんにちわ」**\\ と、\r\n言った\r\nんです",
+			Expected:    "<p>太郎は\\ <strong>「こんにちわ」</strong>\\ と、言ったんです</p>",
+		},
+		t,
+	)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -836,11 +836,18 @@ func IsAlphaNumeric(c byte) bool {
 
 // IsEastAsianWideRune returns trhe if the given rune is an east asian wide character, otherwise false.
 func IsEastAsianWideRune(r rune) bool {
+	// https://en.wikipedia.org/wiki/CJK_Symbols_and_Punctuation
+	var CJKSymbolsAndPunctuation = &unicode.RangeTable{
+		R16: []unicode.Range16{
+			{0x3000, 0x303F, 1},
+		},
+	}
 	return unicode.Is(unicode.Hiragana, r) ||
 		unicode.Is(unicode.Katakana, r) ||
 		unicode.Is(unicode.Han, r) ||
 		unicode.Is(unicode.Lm, r) ||
-		unicode.Is(unicode.Hangul, r)
+		unicode.Is(unicode.Hangul, r) ||
+		unicode.Is(CJKSymbolsAndPunctuation, r)
 }
 
 // A BufWriter is a subset of the bufio.Writer .


### PR DESCRIPTION
**Description:**

This PR introduces an enhancement to the `IsEastAsianWideRune` function. The primary aim is to ensure that characters within the CJK Symbols and Punctuation range are correctly recognized as East Asian wide characters.

**Rationale:**

In the previous implementation, Japanese punctuation and certain related characters were not comprehensively covered. This oversight could lead to potential parsing inaccuracies when dealing with texts containing these characters. By extending support for these Unicode ranges, we can ensure a more accurate and inclusive representation of East Asian texts.

I appreciate any feedback and am open to making further adjustments if needed.