### PR TITLE
update unsafe code to user newer-faster-better idioms

### DIFF
--- a/util/util_unsafe_go120.go
+++ b/util/util_unsafe_go120.go
@@ -1,5 +1,5 @@
-//go:build !appengine && !js
-// +build !appengine,!js
+//go:build !appengine && !js && !go1.21
+// +build !appengine,!js,!go1.21
 
 package util
 

--- a/util/util_unsafe_go121.go
+++ b/util/util_unsafe_go121.go
@@ -1,0 +1,18 @@
+//go:build !appengine && !js && go1.21
+// +build !appengine,!js,go1.21
+
+package util
+
+import (
+	"unsafe"
+)
+
+// BytesToReadOnlyString returns a string converted from given bytes.
+func BytesToReadOnlyString(b []byte) string {
+	return unsafe.String(unsafe.SliceData(b), len(b))
+}
+
+// StringToReadOnlyBytes returns bytes converted from given string.
+func StringToReadOnlyBytes(s string) []byte {
+	return unsafe.Slice(unsafe.StringData(s), len(s))
+}


### PR DESCRIPTION
The new unsafe string/slice functions insulate the code from unlikely-but-still-possible changes to string and slice representation, and tend to compile to slightly better code.  Build tags keep things working with older toolchains.