### PR TITLE
Add `AutoLink.LabelSegment` method

### DIFF
--- a/ast/inline.go
+++ b/ast/inline.go
@@ -503,6 +503,11 @@ func (n *AutoLink) Label(source []byte) []byte {
 	return n.value.Text(source)
 }
 
+// LabelSegment returns a source position of label text in a source text.
+func (n *AutoLink) LabelSegment() textm.Segment {
+	return n.value.Segment
+}
+
 // NewAutoLink returns a new AutoLink node.
 func NewAutoLink(typ AutoLinkType, value *Text) *AutoLink {
 	return &AutoLink{


### PR DESCRIPTION
This PR adds `AutoLink.Segment` method to get the source position of the node. Please see the discussion for more details: https://github.com/yuin/goldmark/discussions/441