### PR TITLE
docu: update example as it will not build

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ markdown := goldmark.New(
                 "https:",
             }),
             extension.WithLinkifyURLRegexp(
-                xurls.Strict,
+                xurls.Strict(),
             ),
         ),
     ),


### PR DESCRIPTION
Hi!

Thanks for the great library.

This is just a minor fix in the documentation to fix the example.

The error was:
```
cannot use xurls.Strict (value of type func() *regexp.Regexp) as *regexp.Regexp value in argument to extension.WithLinkifyURLRegexp
```
