### PR TITLE
make RenderAttributes() accept both []byte and string

### DIFF
--- a/renderer/html/html.go
+++ b/renderer/html/html.go
@@ -786,7 +786,14 @@ func RenderAttributes(w util.BufWriter, node ast.Node, filter util.BytesFilter) 
 		_, _ = w.Write(attr.Name)
 		_, _ = w.WriteString(`="`)
 		// TODO: convert numeric values to strings
-		_, _ = w.Write(util.EscapeHTML(attr.Value.([]byte)))
+		var value []byte
+		switch typed := attr.Value.(type) {
+		case []byte:
+			value = typed
+		case string:
+			value = util.StringToReadOnlyBytes(typed)
+		}
+		_, _ = w.Write(util.EscapeHTML(value))
 		_ = w.WriteByte('"')
 	}
 }


### PR DESCRIPTION
The problem:

Since the [`Value` of an `Attribute`][value] is defined as of type `interface{}`, I may think that it accepts all usual types (such as `[]byte`, `string`, and even numbers).

The problem is that when I ``SetAttributeString(`target`, `_blank`)`` of a `Link`, the `RenderAttributes` function force the Value to be `[]byte`, which results in runtime panic.

<https://github.com/yuin/goldmark/blob/ce6424aa0e15504f675a0f224972d3c8d0c86654/renderer/html/html.go#L789>

[value]: https://github.com/yuin/goldmark/blob/ce6424aa0e15504f675a0f224972d3c8d0c86654/ast/ast.go#L45

The solution:

I switch cased the type and rewritten the code as below:

```go
		var value []byte
		switch typed := attr.Value.(type) {
		case []byte:
			value = typed
		case string:
			value = util.StringToReadOnlyBytes(typed)
		}
		_, _ = w.Write(util.EscapeHTML(value))
```

I cannot assume that people don't force the Value to be of type `[]byte`, or that they already know that, and while `SetAttributeString`,  use `[]byte`. May god bless all those who switch case `Node::AttributeString()`'s return value.