### PR TITLE
GitHub flavored markdown: support single-tilde strikethrough

### DIFF
--- a/extension/_test/strikethrough.txt
+++ b/extension/_test/strikethrough.txt
@@ -16,3 +16,12 @@ new paragraph~~.
 <p>This ~~has a</p>
 <p>new paragraph~~.</p>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
+
+
+
+3
+//- - - - - - - - -//
+~Hi~ Hello, world!
+//- - - - - - - - -//
+<p><del>Hi</del> Hello, world!</p>
+//= = = = = = = = = = = = = = = = = = = = = = = =//

--- a/extension/strikethrough.go
+++ b/extension/strikethrough.go
@@ -46,7 +46,7 @@ func (s *strikethroughParser) Trigger() []byte {
 func (s *strikethroughParser) Parse(parent gast.Node, block text.Reader, pc parser.Context) gast.Node {
 	before := block.PrecendingCharacter()
 	line, segment := block.PeekLine()
-	node := parser.ScanDelimiter(line, before, 2, defaultStrikethroughDelimiterProcessor)
+	node := parser.ScanDelimiter(line, before, 1, defaultStrikethroughDelimiterProcessor)
 	if node == nil {
 		return nil
 	}


### PR DESCRIPTION
According to the [GitHub Flavored Markdown](https://github.github.com/gfm/) spec, strikethrough can use either one or two tildes. Currently, the `Strikethrough` extension only parses the two tilde form. This makes a tiny modification to reduce the minimum delimiter size for the Strikethrough extension so that it can correctly parse the single-tilde form.