### PR TITLE
Add Text() retrieval for BaseBlock types

### DIFF
--- a/ast/block.go
+++ b/ast/block.go
@@ -1,6 +1,7 @@
 package ast
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -45,6 +46,14 @@ func (b *BaseBlock) Lines() *textm.Segments {
 // SetLines implements Node.SetLines.
 func (b *BaseBlock) SetLines(v *textm.Segments) {
 	b.lines = v
+}
+
+func (b *BaseBlock) Text(source []byte) []byte {
+	var buf bytes.Buffer
+	for _, line := range b.Lines().Sliced(0, b.Lines().Len()) {
+		buf.Write(line.Value(source))
+	}
+	return buf.Bytes()
 }
 
 // A Document struct is a root node of Markdown text.


### PR DESCRIPTION
I was trying to use the ast to parse code blocks, and noticed that `Text()` was always returning empty data.

After digging into this a bit I discovered that the `BaseNode` type only retrieves Text from child nodes. However, the `BaseBlock` type (used for code and fenced code blocks) does not have children. Instead, it needs its own `Text()` implementation to enumerate `Lines()` to retrieve the text segment(s) identified during parsing.

If you would like to verify that the code change resolves the issue, please comment out the new code in `ast/block.go` and run the tests.

I've also verified this fix against the test program included in #459.

Thanks!

Closes #459 