### PR TITLE
Ordered kv's in dumps

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -4,6 +4,7 @@ package ast
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 
 	textm "github.com/yuin/goldmark/text"
@@ -449,8 +450,17 @@ func DumpHelper(v Node, source []byte, level int, kv map[string]string, cb func(
 		fmt.Printf("\"\n")
 		fmt.Printf("%sHasBlankPreviousLines: %v\n", indent2, v.HasBlankPreviousLines())
 	}
-	for name, value := range kv {
-		fmt.Printf("%s%s: %s\n", indent2, name, value)
+	if len(kv) > 0 {
+		sortedKV := make([][2]string, 0, len(kv))
+		for name, value := range kv {
+			sortedKV = append(sortedKV, [2]string{name, value})
+		}
+		sort.Slice(sortedKV, func(i, j int) bool {
+			return sortedKV[i][0] < sortedKV[j][0]
+		})
+		for _, kv := range sortedKV {
+			fmt.Printf("%s%s: %s\n", indent2, kv[0], kv[1])
+		}
 	}
 	if cb != nil {
 		cb(level + 1)

--- a/extension/table.go
+++ b/extension/table.go
@@ -184,6 +184,7 @@ func (b *tableParagraphTransformer) Transform(node *gast.Paragraph, reader text.
 func (b *tableParagraphTransformer) parseRow(segment text.Segment,
 	alignments []ast.Alignment, isHeader bool, reader text.Reader, pc parser.Context) *ast.TableRow {
 	source := reader.Source()
+	segment.Padding = 0 // trim padding
 	line := segment.Value(source)
 	pos := 0
 	pos += util.TrimLeftSpaceLength(line)

--- a/extension/table_test.go
+++ b/extension/table_test.go
@@ -355,3 +355,40 @@ bar | baz
 		t,
 	)
 }
+
+func TestTableFuzzedPanics(t *testing.T) {
+	markdown := goldmark.New(
+		goldmark.WithRendererOptions(
+			html.WithXHTML(),
+			html.WithUnsafe(),
+		),
+		goldmark.WithExtensions(
+			NewTable(),
+		),
+	)
+	testutil.DoTestCase(
+		markdown,
+		testutil.MarkdownTestCase{
+			No:          1,
+			Description: "This should not panic",
+			Markdown:    "* 0\n-|\n\t0",
+			Expected: `<ul>
+<li>
+<table>
+<thead>
+<tr>
+<th>0</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>0</td>
+</tr>
+</tbody>
+</table>
+</li>
+</ul>`,
+		},
+		t,
+	)
+}


### PR DESCRIPTION
I was writing a serializer/deserializer for goldmark AST and was comparing `.Dump`'s output to quickly check that AST survives the roundtrip encoding intact. But since `DumpHelper` uses Golang's `map` for the `kv`'s, the output is not deterministic (kv's are swapped randomly).

This PR solves this (admittedly very niche) issue by sorting the kv's by key before printing them out. I used `sort.Slice` instead of more modern `slices.Sort` to preserve the minimal supported go version.

I don't think that this issue is worth the pain of changing `DumpHelper`'s signature to use slices for `kv`, especially since it is a public func, but perhaps it's worth the tiny inefficiency of sorting the values. What do you think?

P.S.: thanks for the great library!