### PR TITLE
Fix panic in table parser

### DIFF
--- a/extension/table.go
+++ b/extension/table.go
@@ -184,11 +184,11 @@ func (b *tableParagraphTransformer) Transform(node *gast.Paragraph, reader text.
 func (b *tableParagraphTransformer) parseRow(segment text.Segment,
 	alignments []ast.Alignment, isHeader bool, reader text.Reader, pc parser.Context) *ast.TableRow {
 	source := reader.Source()
+	segment = segment.TrimLeftSpace(source)
+	segment = segment.TrimRightSpace(source)
 	line := segment.Value(source)
 	pos := 0
-	pos += util.TrimLeftSpaceLength(line)
 	limit := len(line)
-	limit -= util.TrimRightSpaceLength(line)
 	row := ast.NewTableRow(alignments)
 	if len(line) > 0 && line[pos] == '|' {
 		pos++

--- a/extension/table_test.go
+++ b/extension/table_test.go
@@ -355,3 +355,40 @@ bar | baz
 		t,
 	)
 }
+
+func TestTableFuzzedPanics(t *testing.T) {
+	markdown := goldmark.New(
+		goldmark.WithRendererOptions(
+			html.WithXHTML(),
+			html.WithUnsafe(),
+		),
+		goldmark.WithExtensions(
+			NewTable(),
+		),
+	)
+	testutil.DoTestCase(
+		markdown,
+		testutil.MarkdownTestCase{
+			No:          1,
+			Description: "This should not panic",
+			Markdown:    "* 0\n-|\n\t0",
+			Expected: `<ul>
+<li>
+<table>
+<thead>
+<tr>
+<th>0</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>0</td>
+</tr>
+</tbody>
+</table>
+</li>
+</ul>`,
+		},
+		t,
+	)
+}


### PR DESCRIPTION
Code in `func (b *tableParagraphTransformer) parseRow` used the segment's `Value` to calculate some offsets as if `Value` always corresponds 1 to 1 to the source. Segments with padding cause incorrect behavior generally, and an out-of-bounds `source` access in pathological cases.

I switched the code to use padding-aware `segment.TrimLeftSpace` and `segment.TrimRightSpace` instead of raw `util.TrimLeftSpaceLength` and `util.TrimRightSpaceLength`