### PR TITLE
Add configurable `CodeClassPrefix` option for HTML renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Parser and Renderer options
 | `html.WithHardWraps` | `-` | Render newlines as `<br>`.|
 | `html.WithXHTML` | `-` | Render as XHTML. |
 | `html.WithUnsafe` | `-` | By default, goldmark does not render raw HTML or potentially dangerous links. With this option, goldmark renders such content as written. |
+| `html.WithCodeClassPrefix` | `string` | Sets a custom prefix for the `class` attribute of `<code>` elements. An empty string removes the prefix. |
 
 ### Built-in extensions
 

--- a/extra_test.go
+++ b/extra_test.go
@@ -219,3 +219,41 @@ func TestDangerousURLStringCase(t *testing.T) {
 		t.Error("Dangerous URL should ignore cases:\n" + string(testutil.DiffPretty(expected, b.Bytes())))
 	}
 }
+
+func TestCodeClassPrefix(t *testing.T) {
+	cases := []struct {
+		prefix   string
+		source   string
+		expected string
+	}{
+		{
+			prefix:   "language-",
+			source:   "```go\ncode\n```",
+			expected: "<pre><code class=\"language-go\">code\n</code></pre>\n",
+		},
+		{
+			prefix:   "custom-",
+			source:   "```go\ncode\n```",
+			expected: "<pre><code class=\"custom-go\">code\n</code></pre>\n",
+		},
+		{
+			prefix:   "",
+			source:   "```go\ncode\n```",
+			expected: "<pre><code class=\"go\">code\n</code></pre>\n",
+		},
+	}
+
+	for _, c := range cases {
+		markdown := New(WithRendererOptions(
+			html.WithCodeClassPrefix(c.prefix),
+		))
+		var b bytes.Buffer
+		err := markdown.Convert([]byte(c.source), &b)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if b.String() != c.expected {
+			t.Errorf("prefix: %q\nsource: %q\nexpected: %q\ngot: %q", c.prefix, c.source, c.expected, b.String())
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces a new configuration option, `CodeClassPrefix`, for the HTML renderer. The `CodeClassPrefix` allows users to set a custom prefix for the `class` attribute of `<code>` elements or remove the prefix entirely by setting it to an empty string.

### Key Changes:
- Added `CodeClassPrefix` to the HTML renderer configuration.
- Introduced the `html.WithCodeClassPrefix` functional option for easy configuration.
- Updated the `<code>` rendering logic to use the configured prefix.
- Added tests to verify the behavior of the `CodeClassPrefix` option.
- Updated the documentation in the README.md to include details about the new option.

This enhancement improves flexibility for users who need custom class prefixes for syntax highlighting or other styling purposes.