### PR TITLE
Add goldmark-treeblood extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ Extensions
 - [goldmark-enclave](https://github.com/quailyquaily/goldmark-enclave): Adds support for embedding youtube/bilibili video, X's [oembed X](https://publish.x.com/), [tradingview chart](https://www.tradingview.com/widget/)'s chart, [quaily widget](https://quaily.com), [spotify embeds](https://developer.spotify.com/documentation/embeds), [dify embed](https://dify.ai/) and html audio into the document.
 - [goldmark-wiki-table](https://github.com/movsb/goldmark-wiki-table): Adds support for embedding Wiki Tables.
 - [goldmark-tgmd](https://github.com/Mad-Pixels/goldmark-tgmd): A Telegram markdown renderer that can be passed to `goldmark.WithRenderer()`.
+- [goldmark-treeblood](https://github.com/Wyatt915/goldmark-treeblood): Renders $\LaTeX$ expressions as MathML (pure Go, no external dependencies).
 
 ### Loading extensions at runtime
 [goldmark-dynamic](https://github.com/yuin/goldmark-dynamic) allows you to write a goldmark extension in Lua and load it at runtime without re-compilation.


### PR DESCRIPTION
This PR adds a mention of the [goldmark-treeblood](https://github.com/Wyatt915/goldmark-treeblood) extension made by @Wyatt915. The main difference between this new extension and previous ones is that this is the first pure Go-implementation of a LaTeX-to-MathML renderer. Therefore, it's free of external dependencies and requires no CGo. The following is from the extension's README.

> goldmark-treeblood is an extension for [goldmark](http://github.com/yuin/goldmark) that renders $LaTeX$ expressions as
MathML, an open web standard for describing mathematical notation. Unlike MathJax or KaTeX, [TreeBlood](https://github.com/Wyatt915/treeblood)
runs server-side, is written in pure Go, and has no dependencies outside the Go standard library.