### PR TITLE
Leave attributes unfiltered if html.WithUnsafe()

### DIFF
--- a/extension/definition_list.go
+++ b/extension/definition_list.go
@@ -205,7 +205,7 @@ func (r *DefinitionListHTMLRenderer) renderDefinitionList(
 	if entering {
 		if n.Attributes() != nil {
 			_, _ = w.WriteString("<dl")
-			html.RenderAttributes(w, n, DefinitionListAttributeFilter)
+			r.RenderAttributes(w, n, DefinitionListAttributeFilter)
 			_, _ = w.WriteString(">\n")
 		} else {
 			_, _ = w.WriteString("<dl>\n")
@@ -224,7 +224,7 @@ func (r *DefinitionListHTMLRenderer) renderDefinitionTerm(
 	if entering {
 		if n.Attributes() != nil {
 			_, _ = w.WriteString("<dt")
-			html.RenderAttributes(w, n, DefinitionTermAttributeFilter)
+			r.RenderAttributes(w, n, DefinitionTermAttributeFilter)
 			_ = w.WriteByte('>')
 		} else {
 			_, _ = w.WriteString("<dt>")
@@ -244,7 +244,7 @@ func (r *DefinitionListHTMLRenderer) renderDefinitionDescription(
 		n := node.(*ast.DefinitionDescription)
 		_, _ = w.WriteString("<dd")
 		if n.Attributes() != nil {
-			html.RenderAttributes(w, n, DefinitionDescriptionAttributeFilter)
+			r.RenderAttributes(w, n, DefinitionDescriptionAttributeFilter)
 		}
 		if n.IsTight {
 			_, _ = w.WriteString(">")

--- a/extension/footnote.go
+++ b/extension/footnote.go
@@ -594,7 +594,7 @@ func (r *FootnoteHTMLRenderer) renderFootnote(
 		_, _ = w.WriteString(is)
 		_, _ = w.WriteString(`"`)
 		if node.Attributes() != nil {
-			html.RenderAttributes(w, node, html.ListItemAttributeFilter)
+			r.RenderAttributes(w, node, html.ListItemAttributeFilter)
 		}
 		_, _ = w.WriteString(">\n")
 	} else {
@@ -608,7 +608,7 @@ func (r *FootnoteHTMLRenderer) renderFootnoteList(
 	if entering {
 		_, _ = w.WriteString(`<div class="footnotes" role="doc-endnotes"`)
 		if node.Attributes() != nil {
-			html.RenderAttributes(w, node, html.GlobalAttributeFilter)
+			r.RenderAttributes(w, node, html.GlobalAttributeFilter)
 		}
 		_ = w.WriteByte('>')
 		if r.Config.XHTML {

--- a/extension/strikethrough.go
+++ b/extension/strikethrough.go
@@ -91,7 +91,7 @@ func (r *StrikethroughHTMLRenderer) renderStrikethrough(
 	if entering {
 		if n.Attributes() != nil {
 			_, _ = w.WriteString("<del")
-			html.RenderAttributes(w, n, StrikethroughAttributeFilter)
+			r.RenderAttributes(w, n, StrikethroughAttributeFilter)
 			_ = w.WriteByte('>')
 		} else {
 			_, _ = w.WriteString("<del>")

--- a/extension/table.go
+++ b/extension/table.go
@@ -375,7 +375,7 @@ func (r *TableHTMLRenderer) renderTable(
 	if entering {
 		_, _ = w.WriteString("<table")
 		if n.Attributes() != nil {
-			html.RenderAttributes(w, n, TableAttributeFilter)
+			r.RenderAttributes(w, n, TableAttributeFilter)
 		}
 		_, _ = w.WriteString(">\n")
 	} else {
@@ -398,7 +398,7 @@ func (r *TableHTMLRenderer) renderTableHeader(
 	if entering {
 		_, _ = w.WriteString("<thead")
 		if n.Attributes() != nil {
-			html.RenderAttributes(w, n, TableHeaderAttributeFilter)
+			r.RenderAttributes(w, n, TableHeaderAttributeFilter)
 		}
 		_, _ = w.WriteString(">\n")
 		_, _ = w.WriteString("<tr>\n") // Header <tr> has no separate handle
@@ -426,7 +426,7 @@ func (r *TableHTMLRenderer) renderTableRow(
 	if entering {
 		_, _ = w.WriteString("<tr")
 		if n.Attributes() != nil {
-			html.RenderAttributes(w, n, TableRowAttributeFilter)
+			r.RenderAttributes(w, n, TableRowAttributeFilter)
 		}
 		_, _ = w.WriteString(">\n")
 	} else {
@@ -512,9 +512,9 @@ func (r *TableHTMLRenderer) renderTableCell(
 		}
 		if n.Attributes() != nil {
 			if tag == "td" {
-				html.RenderAttributes(w, n, TableTdCellAttributeFilter) // <td>
+				r.RenderAttributes(w, n, TableTdCellAttributeFilter) // <td>
 			} else {
-				html.RenderAttributes(w, n, TableThCellAttributeFilter) // <th>
+				r.RenderAttributes(w, n, TableThCellAttributeFilter) // <th>
 			}
 		}
 		_ = w.WriteByte('>')

--- a/renderer/html/html.go
+++ b/renderer/html/html.go
@@ -313,7 +313,7 @@ func (r *Renderer) renderHeading(
 		_, _ = w.WriteString("<h")
 		_ = w.WriteByte("0123456"[n.Level])
 		if n.Attributes() != nil {
-			RenderAttributes(w, node, HeadingAttributeFilter)
+			r.RenderAttributes(w, node, HeadingAttributeFilter)
 		}
 		_ = w.WriteByte('>')
 	} else {
@@ -332,7 +332,7 @@ func (r *Renderer) renderBlockquote(
 	if entering {
 		if n.Attributes() != nil {
 			_, _ = w.WriteString("<blockquote")
-			RenderAttributes(w, n, BlockquoteAttributeFilter)
+			r.RenderAttributes(w, n, BlockquoteAttributeFilter)
 			_ = w.WriteByte('>')
 		} else {
 			_, _ = w.WriteString("<blockquote>\n")
@@ -414,7 +414,7 @@ func (r *Renderer) renderList(w util.BufWriter, source []byte, node ast.Node, en
 			_, _ = fmt.Fprintf(w, " start=\"%d\"", n.Start)
 		}
 		if n.Attributes() != nil {
-			RenderAttributes(w, n, ListAttributeFilter)
+			r.RenderAttributes(w, n, ListAttributeFilter)
 		}
 		_, _ = w.WriteString(">\n")
 	} else {
@@ -432,7 +432,7 @@ func (r *Renderer) renderListItem(w util.BufWriter, source []byte, n ast.Node, e
 	if entering {
 		if n.Attributes() != nil {
 			_, _ = w.WriteString("<li")
-			RenderAttributes(w, n, ListItemAttributeFilter)
+			r.RenderAttributes(w, n, ListItemAttributeFilter)
 			_ = w.WriteByte('>')
 		} else {
 			_, _ = w.WriteString("<li>")
@@ -456,7 +456,7 @@ func (r *Renderer) renderParagraph(w util.BufWriter, source []byte, n ast.Node, 
 	if entering {
 		if n.Attributes() != nil {
 			_, _ = w.WriteString("<p")
-			RenderAttributes(w, n, ParagraphAttributeFilter)
+			r.RenderAttributes(w, n, ParagraphAttributeFilter)
 			_ = w.WriteByte('>')
 		} else {
 			_, _ = w.WriteString("<p>")
@@ -486,7 +486,7 @@ func (r *Renderer) renderThematicBreak(
 	}
 	_, _ = w.WriteString("<hr")
 	if n.Attributes() != nil {
-		RenderAttributes(w, n, ThematicAttributeFilter)
+		r.RenderAttributes(w, n, ThematicAttributeFilter)
 	}
 	if r.XHTML {
 		_, _ = w.WriteString(" />\n")
@@ -514,7 +514,7 @@ func (r *Renderer) renderAutoLink(
 	_, _ = w.Write(util.EscapeHTML(util.URLEscape(url, false)))
 	if n.Attributes() != nil {
 		_ = w.WriteByte('"')
-		RenderAttributes(w, n, LinkAttributeFilter)
+		r.RenderAttributes(w, n, LinkAttributeFilter)
 		_ = w.WriteByte('>')
 	} else {
 		_, _ = w.WriteString(`">`)
@@ -531,7 +531,7 @@ func (r *Renderer) renderCodeSpan(w util.BufWriter, source []byte, n ast.Node, e
 	if entering {
 		if n.Attributes() != nil {
 			_, _ = w.WriteString("<code")
-			RenderAttributes(w, n, CodeAttributeFilter)
+			r.RenderAttributes(w, n, CodeAttributeFilter)
 			_ = w.WriteByte('>')
 		} else {
 			_, _ = w.WriteString("<code>")
@@ -566,7 +566,7 @@ func (r *Renderer) renderEmphasis(
 		_ = w.WriteByte('<')
 		_, _ = w.WriteString(tag)
 		if n.Attributes() != nil {
-			RenderAttributes(w, n, EmphasisAttributeFilter)
+			r.RenderAttributes(w, n, EmphasisAttributeFilter)
 		}
 		_ = w.WriteByte('>')
 	} else {
@@ -591,7 +591,7 @@ func (r *Renderer) renderLink(w util.BufWriter, source []byte, node ast.Node, en
 			_ = w.WriteByte('"')
 		}
 		if n.Attributes() != nil {
-			RenderAttributes(w, n, LinkAttributeFilter)
+			r.RenderAttributes(w, n, LinkAttributeFilter)
 		}
 		_ = w.WriteByte('>')
 	} else {
@@ -621,7 +621,7 @@ func (r *Renderer) renderImage(w util.BufWriter, source []byte, node ast.Node, e
 		_ = w.WriteByte('"')
 	}
 	if n.Attributes() != nil {
-		RenderAttributes(w, n, ImageAttributeFilter)
+		r.RenderAttributes(w, n, ImageAttributeFilter)
 	}
 	if r.XHTML {
 		_, _ = w.WriteString(" />")
@@ -720,9 +720,9 @@ var dataPrefix = []byte("data-")
 // RenderAttributes renders given node's attributes.
 // You can specify attribute names to render by the filter.
 // If filter is nil, RenderAttributes renders all attributes.
-func RenderAttributes(w util.BufWriter, node ast.Node, filter util.BytesFilter) {
+func (c *Config) RenderAttributes(w util.BufWriter, node ast.Node, filter util.BytesFilter) {
 	for _, attr := range node.Attributes() {
-		if filter != nil && !filter.Contains(attr.Name) {
+		if !c.Unsafe && filter != nil && !filter.Contains(attr.Name) {
 			if !bytes.HasPrefix(attr.Name, dataPrefix) {
 				continue
 			}


### PR DESCRIPTION
I made this change so that I could use an ASTTransformer to add [HTMX attributes](https://htmx.org/reference/#attributes) to my links. I understand it's a breaking change to goldmark's public API in this form, and so unlikely to get merged. But I thought I'd leave it here just in case