### PR TITLE
Insert raw HTML that is a void element and an inline element (phrasing content) within a paragraph.

### DIFF
--- a/_test/extra.txt
+++ b/_test/extra.txt
@@ -876,3 +876,19 @@ text" /></p>
 </li>
 </ul>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
+
+70: Raw inline elements that are void elements
+//- - - - - - - - -//
+<img src="https:/example.com/image.png" alt="An image" title="Image title" />
+
+<input type="text" name="name" value="value">
+
+<br>
+
+<wbr />
+//- - - - - - - - -//
+<p><img src="https:/example.com/image.png" alt="An image" title="Image title" /></p>
+<p><input type="text" name="name" value="value"></p>
+<p><br></p>
+<p><wbr /></p>
+//= = = = = = = = = = = = = = = = = = = = = = = =//

--- a/parser/html_block.go
+++ b/parser/html_block.go
@@ -95,6 +95,8 @@ var htmlBlockType6Regexp = regexp.MustCompile(`^[ ]{0,3}<(?:/[ ]*)?([a-zA-Z]+[a-
 
 var htmlBlockType7Regexp = regexp.MustCompile(`^[ ]{0,3}<(/[ ]*)?([a-zA-Z]+[a-zA-Z0-9\-]*)(` + attributePattern + `*)[ ]*(?:>|/>)[ ]*(?:\r\n|\n)?$`) //nolint:golint,lll
 
+var voidInlineElementRegexp = regexp.MustCompile(`^[ ]{0,3}<(img|input|w?br)(?:[ ].*|/?>)`)
+
 type htmlBlockParser struct {
 }
 
@@ -136,7 +138,8 @@ func (b *htmlBlockParser) Open(parent ast.Node, reader text.Reader, pc Context) 
 		if ok {
 			node = ast.NewHTMLBlock(ast.HTMLBlockType6)
 		} else if tagName != "script" && tagName != "style" &&
-			tagName != "pre" && !ast.IsParagraph(last) && !(isCloseTag && hasAttr) { // type 7 can not interrupt paragraph
+			tagName != "pre" && !ast.IsParagraph(last) && !(isCloseTag && hasAttr) &&
+			!voidInlineElementRegexp.Match(line) { // type 7 can not interrupt paragraph
 			node = ast.NewHTMLBlock(ast.HTMLBlockType7)
 		}
 	}


### PR DESCRIPTION
fix #526 

I have placed the void element, which is also phrasing content, within a paragraph.

ref. https://developer.mozilla.org/en-US/docs/Glossary/Void_element