### PR TITLE
Add goldmark-subtext to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ Extensions
 - [goldmark-wiki-table](https://github.com/movsb/goldmark-wiki-table): Adds support for embedding Wiki Tables.
 - [goldmark-tgmd](https://github.com/Mad-Pixels/goldmark-tgmd): A Telegram markdown renderer that can be passed to `goldmark.WithRenderer()`.
 - [goldmark-treeblood](https://github.com/Wyatt915/goldmark-treeblood): Renders $\LaTeX$ expressions as MathML (pure Go, no external dependencies).
+- [goldmark-subtext](https://github.com/zeozeozeo/goldmark-subtext): Support for Discord-style markdown subtexts
 
 ### Loading extensions at runtime
 [goldmark-dynamic](https://github.com/yuin/goldmark-dynamic) allows you to write a goldmark extension in Lua and load it at runtime without re-compilation.


### PR DESCRIPTION
Add [goldmark-subtext](github.com/zeozeozeo/goldmark-subtext) to the list of extensions in the readme.

It allows for Discord-style subtexts:

```md
# this is a header

-# this is a small subtext, rendered with <small>
```