### PR TITLE
add goldmark-customtag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ Extensions
 - [goldmark-tgmd](https://github.com/Mad-Pixels/goldmark-tgmd): A Telegram markdown renderer that can be passed to `goldmark.WithRenderer()`.
 - [goldmark-treeblood](https://github.com/Wyatt915/goldmark-treeblood): Renders $\LaTeX$ expressions as MathML (pure Go, no external dependencies).
 - [goldmark-subtext](https://github.com/zeozeozeo/goldmark-subtext): Support for Discord-style markdown subtexts
+- [goldmark-customtag](https://github.com/tendstofortytwo/goldmark-customtag): Allows you to define custom block tags.
 
 ### Loading extensions at runtime
 [goldmark-dynamic](https://github.com/yuin/goldmark-dynamic) allows you to write a goldmark extension in Lua and load it at runtime without re-compilation.


### PR DESCRIPTION
if the extension is called like `customtag.New("::", "aside")`, it will perform this kind of translation, similar to `>` turning into `blockquote` tags:

source:
```
:: *this* sort of text,
::
:: spread across multiple paragraphs
```
result:
```
<aside>
    <p><em>this</em> sort of text,</p>
    <p>spread across multiple paragraphs</p>
</aside>
```