### PR TITLE
fix(linkify): reject SCP-style SSH URIs from email autolink detection

### DIFF
--- a/extension/linkify.go
+++ b/extension/linkify.go
@@ -267,6 +267,11 @@ func (s *linkifyParser) Parse(parent ast.Node, block text.Reader, pc parser.Cont
 			if nextChar == '-' || nextChar == '_' {
 				return nil
 			}
+			// Reject SSH-style URIs like git@github.com:user/repo
+			// A colon after the domain indicates an SCP-style path, not an email.
+			if nextChar == ':' {
+				return nil
+			}
 		}
 	}
 	if m == nil {


### PR DESCRIPTION
## Summary
- Fix SCP-style Git URIs (`git@github.com:user/repo`) being incorrectly detected as email addresses by the linkify extension

## Problem
```markdown
git@gitea.com:gitea/tea
```
Was being converted to a `mailto:` link, producing:
```
git@gitea.com mailto:git@gitea.com:gitea/tea
```

## Root Cause
The linkify email detection matches `user@domain` patterns, and `git@github.com` fits that pattern. The `:user/repo` suffix was not being checked.

## Fix
After email domain matching, check if the next character is `:`. If so, reject the match — a colon after the domain indicates an SCP-style path (`user@host:path`), not a valid email address.

Valid emails (`user@example.com` followed by space, punctuation, or end of string) are unaffected.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 1.8s of tests including GFM spec tests)

Related: charmbracelet/glamour#82

🤖 Generated with [Claude Code](https://claude.com/claude-code)