### PR TITLE
fix(linkify): strip trailing quotes from auto-linked URLs

### DIFF
--- a/extension/linkify.go
+++ b/extension/linkify.go
@@ -234,6 +234,8 @@ func (s *linkifyParser) Parse(parent ast.Node, block text.Reader, pc parser.Cont
 					m[1] -= m[1] - i
 				}
 			}
+		} else if lastChar == '"' || lastChar == '\'' {
+			m[1]--
 		}
 	}
 	if m == nil {


### PR DESCRIPTION
Fixes #335

## Problem

When both linkify and typographer extensions are enabled, a quoted URL like `"https://example.org/"` produces a broken href:

```html
<!-- Expected -->
<p>&ldquo;<a href="https://example.org/">https://example.org/</a>&rdquo;</p>

<!-- Actual (before fix) -->
<p>&ldquo;<a href="https://example.org/%22">https://example.org/&quot;</a></p>
```

The linkify parser includes the trailing `"` as part of the URL. The typographer extension converts the opening `"` to `&ldquo;` but the closing `"` is already inside the URL, resulting in `%22` in the href.

## Fix

Add `"` and `'` to the trailing punctuation characters that linkify strips from auto-detected URLs, matching the existing behavior for `.`, `)`, and `;` (HTML entities).

## Testing

All existing tests pass. The fix is a 2-line addition to the existing trailing-character trimming logic.