### PR TITLE
fix: stop typographer mangling opening quote of quoted 't' words

### DIFF
--- a/extension/_test/typographer.txt
+++ b/extension/_test/typographer.txt
@@ -141,3 +141,10 @@ We're talking about the internet --- 'net for short. Let's rock 'n roll!
 //- - - - - - - - -//
 <p><img src="https://example.com/image.jpg" alt="Nice &amp; day, isn&rsquo;t it?"></p>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
+
+20: Quoted words starting with 't' keep their opening quote
+//- - - - - - - - -//
+It was 'terrifying' but 'twas worth it; please 'turn' here.
+//- - - - - - - - -//
+<p>It was &lsquo;terrifying&rsquo; but &rsquo;twas worth it; please &lsquo;turn&rsquo; here.</p>
+//= = = = = = = = = = = = = = = = = = = = = = = =//

--- a/extension/typographer.go
+++ b/extension/typographer.go
@@ -231,9 +231,10 @@ func (s *typographerParser) Parse(parent gast.Node, block text.Reader, pc parser
 						return node
 					}
 				}
-				// special cases: 'twas, 'em, 'net
+				// special cases: 'twas/'tis, 'em, 'net (a leading 't only counts before w/i, so quoted words like 'terrifying' keep their opening quote)
 				if len(line) > 1 && (unicode.IsPunct(before) || unicode.IsSpace(before)) &&
-					(line[1] == 't' || line[1] == 'e' || line[1] == 'n' || line[1] == 'l') {
+					((line[1] == 't' && len(line) > 2 && (line[2] == 'w' || line[2] == 'i')) ||
+						line[1] == 'e' || line[1] == 'n' || line[1] == 'l') {
 					node := gast.NewString(s.Substitutions[Apostrophe])
 					node.SetCode(true)
 					block.Advance(1)


### PR DESCRIPTION
- [x] goldmark is an extensible library. I will no longer accept PRs that add non-CommonMark features to the core parser. Please implement non-CommonMark features as extensions.
  - [x] If you need addtional goldmark functionalities for implementing non-CommonMark features, please create PR that only adds these functionalities without extensions adding non-CommonMark features.
    - DO NOT hesitate copy&paste some logics from goldmark. Copy&paste is not always bad. Many users claim like 'To implement this as an external extension, it would require copy and paste from goldmark, so I implemented it in the core.' . Please copy&paste some logics from goldmark if needed.
  - I welcome PRs that add your extensions to README :)
- [x] goldmark is a CommonMark parser. I do not discuss about specs here. Please post your questions about CommonMark specs at [CommonMark spec repository](https://github.com/commonmark/commonmark-spec/issues).

The typographer's `'twas`/`'em`/`'net` contraction shortcut was triggered by any apostrophe-prefixed word starting with `t`, so quoted words like `'terrifying'` or `'them'` lost their opening curly quote. The leading `'t` shortcut now only fires before `w`/`i` (`'twas`, `'tis`, `'twixt`, ...), while `'twas` and friends still work. Closes #347.
