### PR TITLE
fix(parser): fenced code block panics on all-whitespace line

### DIFF
--- a/extra_test.go
+++ b/extra_test.go
@@ -279,3 +279,13 @@ func TestDangerousURLWithReferences(t *testing.T) {
 		t.Error("Dangerous image should not be rendered:\n" + string(testutil.DiffPretty(expected, b.Bytes())))
 	}
 }
+
+func TestFencedCodeBlockOnBlankLine(t *testing.T) {
+	// BlockIndent returns -1 for all-whitespace lines, which must not be used
+	// to index the line in the fenced code block parser.
+	source := []byte("*\n\t* \t~")
+	var b bytes.Buffer
+	if err := New().Convert(source, &b); err != nil {
+		t.Error(err.Error())
+	}
+}

--- a/parser/fcode_block.go
+++ b/parser/fcode_block.go
@@ -35,6 +35,9 @@ func (b *fencedCodeBlockParser) Trigger() []byte {
 func (b *fencedCodeBlockParser) Open(parent ast.Node, reader text.Reader, pc Context) (ast.Node, State) {
 	line, segment := reader.PeekLine()
 	pos := pc.BlockIndent()
+	if pos < 0 {
+		return nil, NoChildren
+	}
 	findent := pos
 	fenceChar := line[pos]
 	i := pos


### PR DESCRIPTION
- [x] goldmark is an extensible library. I will no longer accept PRs that add non-CommonMark features to the core parser. Please implement non-CommonMark features as extensions.
  - [x] If you need addtional goldmark functionalities for implementing non-CommonMark features, please create PR that only adds these functionalities without extensions adding non-CommonMark features.
    - DO NOT hesitate copy&paste some logics from goldmark. Copy&paste is not always bad. Many users claim like 'To implement this as an external extension, it would require copy and paste from goldmark, so I implemented it in the core.' . Please copy&paste some logics from goldmark if needed.
  - I welcome PRs that add your extensions to README :)
- [x] goldmark is a CommonMark parser. I do not discuss about specs here. Please post your questions about CommonMark specs at [CommonMark spec repository](https://github.com/commonmark/commonmark-spec/issues).

---

Fixes #556.

`BlockIndent()` returns `-1` for blank or all-whitespace lines, but `fencedCodeBlockParser.Open` used the value directly to index the line (`line[pos]`), so an all-whitespace line after list-prefix stripping panicked with `index out of range [-1]`. The `Continue` method already guards with `if pos < 0`, and the indented `codeBlockParser` does the same; this adds the matching guard to `Open`.

Minimal input (found by the Go fuzzer): `"*\n\t* \t~"`.

Added a regression test in `extra_test.go`. `go test ./...` passes.
