### PR TITLE
fix: avoid panic in fenced code block parser on blank line

### DIFF
--- a/fuzz/testdata/fuzz/FuzzDefault/fenced_code_block_blank_indent
+++ b/fuzz/testdata/fuzz/FuzzDefault/fenced_code_block_blank_indent
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("*\n\t* \t~")

--- a/parser/fcode_block.go
+++ b/parser/fcode_block.go
@@ -35,6 +35,11 @@ func (b *fencedCodeBlockParser) Trigger() []byte {
 func (b *fencedCodeBlockParser) Open(parent ast.Node, reader text.Reader, pc Context) (ast.Node, State) {
 	line, segment := reader.PeekLine()
 	pos := pc.BlockIndent()
+	if pos < 0 {
+		// BlockIndent returns -1 for a blank or all-whitespace line, which
+		// cannot start a fenced code block.
+		return nil, NoChildren
+	}
 	findent := pos
 	fenceChar := line[pos]
 	i := pos

--- a/parser/fcode_block.go
+++ b/parser/fcode_block.go
@@ -34,9 +34,9 @@ func (b *fencedCodeBlockParser) Trigger() []byte {
 
 func (b *fencedCodeBlockParser) Open(parent ast.Node, reader text.Reader, pc Context) (ast.Node, State) {
 	line, segment := reader.PeekLine()
-	pos := pc.BlockIndent()
+	pos := pc.BlockOffset()
 	if pos < 0 {
-		// BlockIndent returns -1 for a blank or all-whitespace line, which
+		// BlockOffset returns -1 for a blank or all-whitespace line, which
 		// cannot start a fenced code block.
 		return nil, NoChildren
 	}


### PR DESCRIPTION
Closes #556.

`fencedCodeBlockParser.Open` reads `line[pos]` where `pos` comes from
`Context.BlockIndent()`. `BlockIndent` is documented to return `-1` for a
blank or all-whitespace line, and the outer `openBlocks` loop does not rule
those lines out before dispatching to the parser. The fuzzer input
`"*\n\t* \t~"` reaches `Open` on such a line, so `line[pos]` becomes
`line[-1]` and panics:

```
panic: runtime error: index out of range [-1] in fencedCodeBlockParser.Open
```

A blank line cannot start a fenced code block, so `Open` now returns
`NoChildren` when `BlockIndent` is negative, matching the existing handling
of `pos < 0` already present in `Continue`.

## Testing

Added the fuzzer input to the `FuzzDefault` seed corpus. `go test ./...`
passes, including the CommonMark spec tests. Reverting the guard makes the
new corpus entry panic with the index-out-of-range above.
