### PR TITLE
parser: fix panic in fenced code block parser on blank lines (#556)

### DIFF
--- a/issue556_test.go
+++ b/issue556_test.go
@@ -1,0 +1,19 @@
+package goldmark_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/yuin/goldmark"
+)
+
+// TestFencedCodeBlockBlankLineNoPanic is a regression test for
+// https://github.com/yuin/goldmark/issues/556: the fenced code block parser
+// panicked with "index out of range [-1]" when opened on a blank / all-whitespace
+// line, where BlockIndent returns -1. Minimal fuzzer input: "*\n\t* \t~".
+func TestFencedCodeBlockBlankLineNoPanic(t *testing.T) {
+	var buf bytes.Buffer
+	if err := goldmark.Convert([]byte("*\n\t* \t~"), &buf); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/parser/fcode_block.go
+++ b/parser/fcode_block.go
@@ -35,6 +35,11 @@ func (b *fencedCodeBlockParser) Trigger() []byte {
 func (b *fencedCodeBlockParser) Open(parent ast.Node, reader text.Reader, pc Context) (ast.Node, State) {
 	line, segment := reader.PeekLine()
 	pos := pc.BlockIndent()
+	if pos < 0 {
+		// BlockIndent returns -1 for blank or all-whitespace lines, which have
+		// no fence character and cannot start a fenced code block.
+		return nil, NoChildren
+	}
 	findent := pos
 	fenceChar := line[pos]
 	i := pos


### PR DESCRIPTION
## Problem

`fencedCodeBlockParser.Open` panics with `runtime error: index out of range [-1]` on certain inputs:

```go
pos := pc.BlockIndent()  // -1 for blank / all-whitespace lines
fenceChar := line[pos]   // line[-1] -> panic
```

`Context.BlockIndent()` returns `-1` for blank or all-whitespace lines, but `Open` used it directly as an index into the line.

Minimal reproducer (found by a Go fuzzer, from #556):

```go
var b bytes.Buffer
goldmark.Convert([]byte("*\n\t* \t~"), &b) // panics before this fix
```

## Fix

A blank / all-whitespace line has no fence character and cannot start a fenced code block, so return `NoChildren` when `BlockIndent()` is negative — before indexing the line.

```go
pos := pc.BlockIndent()
if pos < 0 {
	return nil, NoChildren
}
```

## Test

Added `TestFencedCodeBlockBlankLineNoPanic`, which converts the reproducer input and asserts it no longer panics. `go test ./...` passes.

Fixes #556