### PR TITLE
docs: fix grammar and article typos in godoc comments

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -519,7 +519,7 @@ const (
 	// WalkStop indicates no more walking needed.
 	WalkStop WalkStatus = iota + 1
 
-	// WalkSkipChildren indicates that Walk wont walk on children of current
+	// WalkSkipChildren indicates that Walk will not walk on children of current
 	// node.
 	WalkSkipChildren
 
@@ -527,13 +527,13 @@ const (
 	WalkContinue
 )
 
-// Walker is a function that will be called when Walk find a
+// Walker is a function that will be called when Walk finds a
 // new node.
 // entering is set true before walks children, false after walked children.
-// If Walker returns error, Walk function immediately stop walking.
+// If Walker returns an error, Walk immediately stops walking.
 type Walker func(n Node, entering bool) (WalkStatus, error)
 
-// Walk walks a AST tree by the depth first search algorithm.
+// Walk walks an AST tree by the depth-first search algorithm.
 func Walk(n Node, walker Walker) error {
 	_, err := walkHelper(n, walker)
 	return err

--- a/ast/block.go
+++ b/ast/block.go
@@ -298,13 +298,13 @@ func NewCodeBlock() *CodeBlock {
 // A FencedCodeBlock struct represents a fenced code block of Markdown text.
 type FencedCodeBlock struct {
 	BaseBlock
-	// Info returns a info text of this fenced code block.
+	// Info returns the info text of this fenced code block.
 	Info *Text
 
 	language []byte
 }
 
-// Language returns an language in an info string.
+// Language returns a language in an info string.
 // Language returns nil if this node does not have an info string.
 func (n *FencedCodeBlock) Language(source []byte) []byte {
 	if n.language == nil && n.Info != nil {

--- a/ast/inline.go
+++ b/ast/inline.go
@@ -585,7 +585,7 @@ func (n *AutoLink) Kind() NodeKind {
 	return KindAutoLink
 }
 
-// URL returns an url of this node.
+// URL returns a URL of this node.
 func (n *AutoLink) URL(source []byte) []byte {
 	if n.Protocol != nil {
 		s := n.value.Segment

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -153,7 +153,7 @@ func NewContextKey() ContextKey {
 	return ContextKeyMax
 }
 
-// A Context interface holds a information that are necessary to parse
+// A Context interface holds information that is necessary to parse
 // Markdown text.
 type Context interface {
 	// String implements Stringer.
@@ -834,7 +834,7 @@ func (p *parser) addParagraphTransformer(v util.PrioritizedValue, options map[Op
 func (p *parser) addASTTransformer(v util.PrioritizedValue, options map[OptionName]any) {
 	at, ok := v.Value.(ASTTransformer)
 	if !ok {
-		panic(fmt.Sprintf("%v is not a ASTTransformer", v.Value))
+		panic(fmt.Sprintf("%v is not an ASTTransformer", v.Value))
 	}
 	so, ok := v.Value.(SetOptioner)
 	if ok {

--- a/util/util.go
+++ b/util/util.go
@@ -742,7 +742,7 @@ func URLEscape(v []byte, resolveReference bool) []byte {
 	return cob.Bytes()
 }
 
-// FindURLIndex returns a stop index value if the given bytes seem an URL.
+// FindURLIndex returns a stop index value if the given bytes seem a URL.
 // This function is equivalent to [A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]* .
 func FindURLIndex(b []byte) int {
 	i := 0


### PR DESCRIPTION
## Summary
Small godoc/comment grammar cleanups found while reading the code:

- \`Language returns an language\` → \`a language\`
- \`returns a info text\` → \`the info text\`
- \`returns an url\` → \`a URL\`
- \`Walk wont walk\` → \`Walk will not walk\`
- \`when Walk find a\` → \`when Walk finds a\`
- \`immediately stop walking\` → \`immediately stops walking\`
- \`walks a AST tree\` → \`an AST tree\`
- Context holds \`a information that are\` → \`information that is\`
- panic: \`not a ASTTransformer\` → \`not an ASTTransformer\`
- \`seem an URL\` → \`seem a URL\`

Docs/string-only; no behavior change.

## Test plan
- [x] Docs and one panic format string only
- [ ] CI green