### PR TITLE
fix: Convert(nil writer) returns error instead of panicking

### DIFF
--- a/markdown.go
+++ b/markdown.go
@@ -2,6 +2,7 @@
 package goldmark
 
 import (
+	"errors"
 	"io"
 
 	"github.com/yuin/goldmark/parser"
@@ -113,6 +114,9 @@ func New(options ...Option) Markdown {
 }
 
 func (m *markdown) Convert(source []byte, writer io.Writer, opts ...parser.ParseOption) error {
+	if writer == nil {
+		return errors.New("goldmark: writer is nil")
+	}
 	reader := text.NewReader(source)
 	doc := m.parser.Parse(reader, opts...)
 	return m.renderer.Render(writer, source, doc)

--- a/nil_writer_test.go
+++ b/nil_writer_test.go
@@ -1,0 +1,19 @@
+package goldmark_test
+
+import (
+	"testing"
+
+	"github.com/yuin/goldmark"
+)
+
+func TestConvertNilWriter(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	err := goldmark.Convert([]byte("# hi"), nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+}


### PR DESCRIPTION
```go
goldmark.Convert([]byte("# hi"), nil) // panic
```

Return `goldmark: writer is nil` instead.