### PR TITLE
fix: strip UTF-8 BOM before parsing markdown

### DIFF
--- a/bom_test.go
+++ b/bom_test.go
@@ -1,0 +1,25 @@
+package goldmark_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/yuin/goldmark"
+)
+
+func TestConvertStripsUTF8BOM(t *testing.T) {
+	src := append([]byte{0xEF, 0xBB, 0xBF}, []byte("# Hi")...)
+	var buf bytes.Buffer
+	if err := goldmark.Convert(src, &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "<h1") || !strings.Contains(out, "Hi") {
+		t.Fatalf("unexpected: %q", out)
+	}
+	// BOM should not appear as content
+	if strings.Contains(out, "\ufeff") {
+		t.Fatalf("BOM leaked into output: %q", out)
+	}
+}

--- a/markdown.go
+++ b/markdown.go
@@ -113,6 +113,11 @@ func New(options ...Option) Markdown {
 }
 
 func (m *markdown) Convert(source []byte, writer io.Writer, opts ...parser.ParseOption) error {
+	// Strip UTF-8 BOM so editors that save with BOM do not produce a leading
+	// zero-width / unexpected first character in the document tree.
+	if len(source) >= 3 && source[0] == 0xEF && source[1] == 0xBB && source[2] == 0xBF {
+		source = source[3:]
+	}
 	reader := text.NewReader(source)
 	doc := m.parser.Parse(reader, opts...)
 	return m.renderer.Render(writer, source, doc)


### PR DESCRIPTION
## What

`Convert` strips a leading UTF-8 BOM (`EF BB BF`) before parsing.

## Why

Some editors save Markdown with a BOM, which otherwise shows up as an unexpected first character / breaks first-line constructs.

## Test

- `TestConvertStripsUTF8BOM`