### PR TITLE
fix: URLEscape validates the same hex digit twice, skipping the byte after %<hex>

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -705,11 +705,6 @@ func URLEscape(v []byte, resolveReference bool) []byte {
 			i += 3
 			continue
 		}
-		u8len := utf8lenTable[c]
-		if u8len == 99 { // invalid utf8 leading byte, skip it
-			i++
-			continue
-		}
 		if c == ' ' {
 			cob.Write(v[n:i])
 			cob.Write(htmlSpace)
@@ -717,23 +712,14 @@ func URLEscape(v []byte, resolveReference bool) []byte {
 			n = i
 			continue
 		}
-		if int(u8len) > len(v) {
-			u8len = int8(len(v) - 1)
-		}
-		if u8len == 0 {
+		r, size := utf8.DecodeRune(v[i:])
+		if r == utf8.RuneError && size == 1 { // invalid or truncated utf8 sequence, skip it
 			i++
-			n = i
 			continue
 		}
 		cob.Write(v[n:i])
-		stop := i + int(u8len)
-		if stop > len(v) {
-			i++
-			n = i
-			continue
-		}
-		cob.Write(StringToReadOnlyBytes(url.QueryEscape(string(v[i:stop]))))
-		i += int(u8len)
+		cob.Write(StringToReadOnlyBytes(url.QueryEscape(string(v[i : i+size]))))
+		i += size
 		n = i
 	}
 	if cob.IsCopied() && n < limit {

--- a/util/util.go
+++ b/util/util.go
@@ -701,7 +701,7 @@ func URLEscape(v []byte, resolveReference bool) []byte {
 			i++
 			continue
 		}
-		if c == '%' && i+2 < limit && IsHexDecimal(v[i+1]) && IsHexDecimal(v[i+1]) {
+		if c == '%' && i+2 < limit && IsHexDecimal(v[i+1]) && IsHexDecimal(v[i+2]) {
 			i += 3
 			continue
 		}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -21,6 +21,11 @@ func TestURLEscape(t *testing.T) {
 		{"/x%A<y", "/x%25A%3Cy"},
 		{"/x%A y", "/x%25A%20y"},
 		{"/x%Aéy", "/x%25A%C3%A9y"},
+		// Malformed utf8 is passed through, not dropped or query escaped.
+		{"/x\xffy", "/x\xffy"},
+		{"a b\xc3", "a%20b\xc3"},
+		{"/x\xe2\x82 y", "/x\xe2\x82%20y"},
+		{"/x\ufffdy", "/x%EF%BF%BDy"},
 	}
 	for _, tt := range tests {
 		if got := string(URLEscape([]byte(tt.in), false)); got != tt.want {
@@ -42,6 +47,18 @@ func TestURLEscapePercentDoesNotSkipNextByte(t *testing.T) {
 		if got := string(URLEscape([]byte(in), false)); got != want {
 			t.Errorf("URLEscape(%q) = %q, want %q (from URLEscape(%q) = %q)",
 				in, got, want, "/xA"+chr(c)+"Z", elsewhere)
+		}
+	}
+}
+
+// A truncated utf8 sequence must be passed through like an invalid leading
+// byte is. "a b" makes the copy on write buffer copy, which exposes the drop.
+func TestURLEscapeTruncatedUTF8(t *testing.T) {
+	for c := 0xc2; c <= 0xf4; c++ {
+		in := "a b" + chr(c)
+		want := "a%20b" + chr(c)
+		if got := string(URLEscape([]byte(in), false)); got != want {
+			t.Errorf("URLEscape(%q) = %q, want %q", in, got, want)
 		}
 	}
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"testing"
+)
+
+func chr(c int) string { return string([]byte{byte(c)}) }
+
+func TestURLEscape(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		// %xx is kept as is.
+		{"/a%41b", "/a%41b"},
+		{"/a%c3%a9b", "/a%c3%a9b"},
+		// A % that does not start a complete triple is escaped.
+		{"/a%zzb", "/a%25zzb"},
+		{"/a%4", "/a%254"},
+		// The byte after %<hex> must be escaped like any other byte.
+		{"/x%A<y", "/x%25A%3Cy"},
+		{"/x%A y", "/x%25A%20y"},
+		{"/x%Aéy", "/x%25A%C3%A9y"},
+	}
+	for _, tt := range tests {
+		if got := string(URLEscape([]byte(tt.in), false)); got != tt.want {
+			t.Errorf("URLEscape(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// How a byte is escaped must not depend on it following a %<hex> pair.
+func TestURLEscapePercentDoesNotSkipNextByte(t *testing.T) {
+	prefix := string(URLEscape([]byte("/x%A"), false))
+	for c := 0; c < 256; c++ {
+		if IsHexDecimal(byte(c)) {
+			continue // %A followed by a hexdecimal is a complete triple
+		}
+		elsewhere := string(URLEscape([]byte("/xA"+chr(c)+"Z"), false))
+		in := "/x%A" + chr(c) + "Z"
+		want := prefix + elsewhere[len("/xA"):]
+		if got := string(URLEscape([]byte(in), false)); got != want {
+			t.Errorf("URLEscape(%q) = %q, want %q (from URLEscape(%q) = %q)",
+				in, got, want, "/xA"+chr(c)+"Z", elsewhere)
+		}
+	}
+}


### PR DESCRIPTION
`util/util.go:704` checks `v[i+1]` twice, so `v[i+2]` is never validated even though `i += 3` consumes it. The byte after `%<hex>` lands in the URL unescaped - 100 of the 234 non-hexdecimal byte values: every C0 control, space, DEL, every byte `utf8lenTable` treats as a leading byte, and `" % < > [ \ ] ^ { | }` plus the backtick.

```
[a](</x%A y>)   ->  <a href="/x%A y">     raw space;  </xA y> gives /xA%20y
[a](/x%Aéy)     ->  <a href="/x%Aéy">     raw utf8;   /xAéy  gives /xA%C3%A9y
```

It reads as a typo rather than a rule: `dd89404` added the line with `result = append(result, c, v[i+1], v[i+2])` directly below it, and the doc comment says `%xx`.

**One behaviour change worth flagging up front:** with the guard fixed, `%<hex><non-hex>` falls onto the existing bare-`%` path, so `[a](/x%4zy)` now gives `/x%254zy` instead of `/x%4zy`. That makes it consistent with `%zz`, which goldmark already escapes to `%25zz` (`urlEscapeTable[0x25] == 0`). cmark-gfm escapes no `%` at all and emits `/x%4zy`, so if you would rather match it that is a change to `urlEscapeTable`, not to this guard, and I left it alone.

The second commit fixes malformed-utf8 handling in the same function, which the first commit makes reachable more often. `URLEscape` trusts `utf8lenTable` for the rune length without checking the bytes are there, so `URLEscape("a b\xc3")` returns `"a%20b"` - the leading byte is dropped, while an invalid one (`\xff`) is passed through - and `url.QueryEscape` gets an incomplete rune, which turns a following space into `+` instead of `%20`. `utf8.DecodeRune`, as `UnicodeCaseFold` already uses at util.go:448, covers both.

`util` had no test file. The new one holds the table above, sweeps all 256 byte values asserting that a byte's escaping does not depend on a preceding `%<hex>`, and checks truncated leads 0xC2-0xF4. `go test ./...` and golangci-lint are green, and ns/op and allocs are unchanged.
