### PR TITLE
Remove Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ goldmark
 [![https://pkg.go.dev/github.com/yuin/goldmark](https://pkg.go.dev/badge/github.com/yuin/goldmark.svg)](https://pkg.go.dev/github.com/yuin/goldmark)
 [![https://github.com/yuin/goldmark/actions?query=workflow:test](https://github.com/yuin/goldmark/actions/workflows/test.yaml/badge.svg?branch=master&event=push)](https://github.com/yuin/goldmark/actions?query=workflow:test)
 [![https://coveralls.io/github/yuin/goldmark](https://coveralls.io/repos/github/yuin/goldmark/badge.svg?branch=master)](https://coveralls.io/github/yuin/goldmark)
-[![https://goreportcard.com/report/github.com/yuin/goldmark](https://goreportcard.com/badge/github.com/yuin/goldmark)](https://goreportcard.com/report/github.com/yuin/goldmark)
 
 > A Markdown parser written in Go. Easy to extend, standards-compliant, well-structured.
 


### PR DESCRIPTION
Removed Go Report Card badge from README.md, as it has been [retired](https://goreportcard.com/)
<img width="156" height="47" alt="image" src="https://github.com/user-attachments/assets/56179e06-eccd-4875-adff-f89953cf4f21" />
