### PR TITLE
fix(linkify): strip unmatched ')' after trailing punctuation

### DIFF
--- a/extension/_test/linkify.txt
+++ b/extension/_test/linkify.txt
@@ -191,3 +191,19 @@ __http://test.com/a/~__
 <strong><a href="http://test.com/">http://test.com/</a>~</strong>
 <strong><a href="http://test.com/a/">http://test.com/a/</a>~</strong></p>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
+
+20: Trailing punctuation then unmatched ')' (GFM path validation order)
+//- - - - - - - - -//
+(https://example.org/).
+
+(https://example.org/):
+
+https://example.org/).
+
+(https://example.org/path_(x)).
+//- - - - - - - - -//
+<p>(<a href="https://example.org/">https://example.org/</a>).</p>
+<p>(<a href="https://example.org/">https://example.org/</a>):</p>
+<p><a href="https://example.org/">https://example.org/</a>).</p>
+<p>(<a href="https://example.org/path_(x)">https://example.org/path_(x)</a>).</p>
+//= = = = = = = = = = = = = = = = = = = = = = = =//

--- a/extension/linkify.go
+++ b/extension/linkify.go
@@ -287,6 +287,24 @@ func (s *linkifyParser) Parse(parent ast.Node, block text.Reader, pc parser.Cont
 	}
 endfor:
 	i++
+	// GFM extended autolink path validation: after removing trailing
+	// punctuation, drop unmatched trailing ')'. This must run after the
+	// punctuation strip so cases like "https://example.org/)." do not keep
+	// the closing parenthesis inside the autolink.
+	if i > 0 && line[i-1] == ')' {
+		closing := 0
+		for j := i - 1; j >= 0; j-- {
+			switch line[j] {
+			case ')':
+				closing++
+			case '(':
+				closing--
+			}
+		}
+		if closing > 0 {
+			i -= closing
+		}
+	}
 	consumes += i
 	block.Advance(consumes)
 	n := ast.NewTextSegment(text.NewSegment(start, start+i))


### PR DESCRIPTION
## Summary

Fixes #571.

GFM [extended autolink path validation](https://github.github.com/gfm/#extended-autolink-path-validation) requires:

1. Strip trailing punctuation (`?`, `!`, `.`, `,`, `:`, `*`, `_`, `~`)
2. Then drop unmatched trailing `)` when the autolink has more closing than opening parentheses

Linkify already did both steps, but step 2 only ran when the regex match **already** ended in `)`. For inputs like `(https://example.org/).` the match ended in `.`, so the `)` balance check was skipped and the parenthesis stayed inside the URL.

## Change

After the existing trailing-punctuation strip, re-run the unmatched-`)` balance check on the final autolink span.

## Test plan

- [x] `go test ./extension/ -run TestLinkify`
- [x] Added case 20 covering `).`, `):`, bare `).`, and balanced `path_(x)).`