### PR TITLE
Fix comma-separated attributes in v2 parser

### DIFF
--- a/parser/attribute.go
+++ b/parser/attribute.go
@@ -51,6 +51,10 @@ func ParseAttributes(reader text.Reader) ([]gast.Attribute, bool) {
 			attrs = append(attrs, attr)
 		}
 		reader.SkipSpaces()
+		if reader.Peek() == ',' {
+			reader.Advance(1)
+			reader.SkipSpaces()
+		}
 	}
 }
 
@@ -178,9 +182,31 @@ func parseAttributeQuoted(reader text.Reader, q byte) (text.MultilineValue, bool
 func parseAttributeUnquoted(reader text.Reader) (text.MultilineValue, bool) {
 	line, seg := reader.PeekLine()
 	i := 0
+	depth := 0
+	var quote byte
 	for ; i < len(line); i++ {
 		c := line[i]
-		if util.IsSpace(c) || c == '}' {
+		if quote != 0 {
+			if c == '\\' {
+				i++
+			} else if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		if depth > 0 && (c == '"' || c == '\'') {
+			quote = c
+			continue
+		}
+		if c == '[' {
+			depth++
+			continue
+		}
+		if c == ']' && depth > 0 {
+			depth--
+			continue
+		}
+		if util.IsSpace(c) || c == '}' || (c == ',' && depth == 0) {
 			break
 		}
 		// ", \, >, <, =, `, and ' are not allowed in unquoted HTML attribute values.

--- a/parser/attribute_test.go
+++ b/parser/attribute_test.go
@@ -9,6 +9,65 @@ import (
 	"github.com/yuin/goldmark/v2/text"
 )
 
+func TestParseAttributesCommaSeparated(t *testing.T) {
+	type expectedAttribute struct {
+		name  string
+		value string
+	}
+	tests := []struct {
+		name   string
+		source string
+		want   []expectedAttribute
+	}{
+		{
+			name:   "numeric values",
+			source: `{start=1,end=2}`,
+			want:   []expectedAttribute{{"start", "1"}, {"end", "2"}},
+		},
+		{
+			name:   "bracketed value",
+			source: `{lines=[8,15,17],start=199}`,
+			want:   []expectedAttribute{{"lines", "[8,15,17]"}, {"start", "199"}},
+		},
+		{
+			name:   "quoted array element",
+			source: `{hl\_lines=[8,"15,17"],linenostart=199}`,
+			want:   []expectedAttribute{{`hl\_lines`, `[8,"15,17"]`}, {"linenostart", "199"}},
+		},
+		{
+			name:   "issue 563",
+			source: `{hl\_lines=[8,"15-17"],linenostart=199}`,
+			want:   []expectedAttribute{{`hl\_lines`, `[8,"15-17"]`}, {"linenostart", "199"}},
+		},
+		{
+			name:   "space separated",
+			source: `{start=1 end=2}`,
+			want:   []expectedAttribute{{"start", "1"}, {"end", "2"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := []byte(test.source)
+			attrs, ok := parser.ParseAttributes(text.NewReader(source))
+			if !ok {
+				t.Fatal("ParseAttributes failed")
+			}
+			if len(attrs) != len(test.want) {
+				t.Fatalf("ParseAttributes returned %d attributes, want %d: %#v", len(attrs), len(test.want), attrs)
+			}
+			for i, attr := range attrs {
+				if attr.Name != test.want[i].name {
+					t.Errorf("attribute %d name = %q, want %q", i, attr.Name, test.want[i].name)
+				}
+				if got := attr.Value.Str(source); got != test.want[i].value {
+					t.Errorf("attribute %d value = %q, want %q", i, got, test.want[i].value)
+				}
+			}
+		})
+	}
+}
+
 func TestUnquotedAttribute(t *testing.T) {
 	source := []byte("{key=value&quot;}")
 	attrs, ok := parser.ParseAttributes(text.NewReader(source))


### PR DESCRIPTION
Fixes #563.

The v2 parser treated a top-level comma as part of an unquoted attribute value. This caused the next attribute to be absorbed into the previous value.

This change:

- treats commas outside bracketed values as attribute separators
- keeps commas inside bracketed and quoted values unchanged
- adds regression coverage for comma-separated and space-separated attributes

Tests:

- `go test ./parser -run '^TestParseAttributesCommaSeparated$' -count=1`
- `go test ./parser`
