### PR TITLE
ci: Add registry-based v1.8.6 vs v2.1.1 benchmark comparison workflow

### DIFF
--- a/.github/workflows/benchmark-comparison.yaml
+++ b/.github/workflows/benchmark-comparison.yaml
@@ -9,8 +9,12 @@ permissions:
 jobs:
 
   compare:
-    # Don't use matrix due to the runner spec cannot be chosen.
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runner:
+          - ubuntu-latest
+          - ubuntu-slim
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -30,7 +34,7 @@ jobs:
             go test -bench . -benchmem -run '^$' -count 10 | tee benchmark.out
 
             {
-              echo "## $version"
+              echo "## $version (${{ matrix.runner }})"
               echo
             } >> "$GITHUB_STEP_SUMMARY"
 
@@ -55,27 +59,22 @@ jobs:
 
               # ns/op
               /^Benchmark/ {
-                ns[++n] = $3
+                ++n
+                ns[n] = $3
                 bytes[n] = $5
+                allocs[n] = $7
               }
 
               END {
-                # Sort ns/op
+                #
+                #   Sort ns/op
+                #
                 for (i = 1; i <= n; i++)
                   for (j = i + 1; j <= n; j++)
                     if (ns[i] > ns[j]) {
                       tmp = ns[i]
                       ns[i] = ns[j]
                       ns[j] = tmp
-                    }
-
-                # Sort B/op
-                for (i = 1; i <= n; i++)
-                  for (j = i + 1; j <= n; j++)
-                    if (bytes[i] > bytes[j]) {
-                      tmp = bytes[i]
-                      bytes[i] = bytes[j]
-                      bytes[j] = tmp
                     }
 
                 # ns/op statistics
@@ -88,6 +87,17 @@ jobs:
                 else
                   ns_median = (ns[n / 2] + ns[n / 2 + 1]) / 2
 
+                #
+                #   Sort B/op
+                #
+                for (i = 1; i <= n; i++)
+                  for (j = i + 1; j <= n; j++)
+                    if (bytes[i] > bytes[j]) {
+                      tmp = bytes[i]
+                      bytes[i] = bytes[j]
+                      bytes[j] = tmp
+                    }
+
                 # B/op statistics
                 bytes_sum = 0
                 for (i = 1; i <= n; i++)
@@ -97,6 +107,27 @@ jobs:
                   bytes_median = bytes[(n + 1) / 2]
                 else
                   bytes_median = (bytes[n / 2] + bytes[n / 2 + 1]) / 2
+
+                #
+                #   Sort allocs/op
+                #
+                for (i = 1; i <= n; i++)
+                  for (j = i + 1; j <= n; j++)
+                    if (allocs[i] > allocs[j]) {
+                      tmp = allocs[i]
+                      allocs[i] = allocs[j]
+                      allocs[j] = tmp
+                    }
+
+                # allocs/op statistics
+                allocs_sum = 0
+                for (i = 1; i <= n; i++)
+                  allocs_sum += allocs[i]
+
+                if (n % 2)
+                  allocs_median = allocs[(n + 1) / 2]
+                else
+                  allocs_median = (allocs[n / 2] + allocs[n / 2 + 1]) / 2
 
                 printf "|   | Median | Average | Min | Max |\n"
                 printf "|--:|-------:|--------:|----:|----:|\n"
@@ -111,6 +142,12 @@ jobs:
                 printf " | %s", comma(bytes_sum / n)
                 printf " | %s", comma(bytes[1])
                 printf " | %s", comma(bytes[n])
+                printf " |\n"
+                printf "| allocs/op"
+                printf " | %s", comma(allocs_median)
+                printf " | %s", comma(allocs_sum / n)
+                printf " | %s", comma(allocs[1])
+                printf " | %s", comma(allocs[n])
                 printf " |\n"
                 printf "\n"
               }

--- a/.github/workflows/benchmark-comparison.yaml
+++ b/.github/workflows/benchmark-comparison.yaml
@@ -30,8 +30,13 @@ jobs:
             local package="$2"
 
             pushd "_benchmark/comparison/$version"
-            go get "$package@latest"
-            go test -bench . -benchmem -run '^$' -count 10 | tee benchmark.out
+
+            {
+              echo '$' go get "$package@latest"
+              go get "$package@latest" 2>&1
+              echo
+              go test -bench . -benchmem -run '^$' -count 10
+            } | tee benchmark.out
 
             {
               echo "## $version (${{ matrix.runner }})"

--- a/.github/workflows/benchmark-comparison.yaml
+++ b/.github/workflows/benchmark-comparison.yaml
@@ -8,27 +8,6 @@ permissions:
 
 jobs:
 
-  benchmark:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
-        id: setup-go
-        with:
-          go-version: 1.27.x
-          check-latest: true
-
-      - name: Benchmark
-        run: |
-          cd _benchmark/go
-
-          go test -bench . -benchmem -run '^$' | tee benchmark.out
-          {
-            echo '```text'
-            cat benchmark.out
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
   compare:
     # Don't use matrix due to the runner spec cannot be chosen.
     runs-on: ubuntu-latest
@@ -67,3 +46,24 @@ jobs:
 
           run_benchmark v2 "github.com/yuin/goldmark/v2"
           run_benchmark v1 "github.com/yuin/goldmark"
+
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        id: setup-go
+        with:
+          go-version: 1.27.x
+          check-latest: true
+
+      - name: Benchmark
+        run: |
+          cd _benchmark/go
+
+          go test -bench . -benchmem -run '^$' | tee benchmark.out
+          {
+            echo '```text'
+            cat benchmark.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/benchmark-comparison.yaml
+++ b/.github/workflows/benchmark-comparison.yaml
@@ -98,17 +98,20 @@ jobs:
                 else
                   bytes_median = (bytes[n / 2] + bytes[n / 2 + 1]) / 2
 
-                printf "ns/op\n"
-                printf "* Min:     %s\n", comma(ns[1])
-                printf "* Max:     %s\n", comma(ns[n])
-                printf "* Median:  %s\n", comma(ns_median)
-                printf "* Average: %s\n", comma(ns_sum / n)
-                printf "\n"
-                printf "B/op\n"
-                printf "* Min:     %s\n", comma(bytes[1])
-                printf "* Max:     %s\n", comma(bytes[n])
-                printf "* Median:  %s\n", comma(bytes_median)
-                printf "* Average: %s\n", comma(bytes_sum / n)
+                printf "|   | Median | Average | Min | Max |\n"
+                printf "|--:|-------:|--------:|----:|----:|\n"
+                printf "| ns/op"
+                printf " | %s", comma(ns_median)
+                printf " | %s", comma(ns_sum / n)
+                printf " | %s", comma(ns[1])
+                printf " | %s", comma(ns[n])
+                printf " |\n"
+                printf "| B/op"
+                printf " | %s", comma(bytes_median)
+                printf " | %s", comma(bytes_sum / n)
+                printf " | %s", comma(bytes[1])
+                printf " | %s", comma(bytes[n])
+                printf " |\n"
                 printf "\n"
               }
               ' benchmark.out >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/benchmark-comparison.yaml
+++ b/.github/workflows/benchmark-comparison.yaml
@@ -1,0 +1,69 @@
+name: benchmark-comparison
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        id: setup-go
+        with:
+          go-version: 1.27.x
+          check-latest: true
+
+      - name: Benchmark
+        run: |
+          cd _benchmark/go
+
+          go test -bench . -benchmem -run '^$' | tee benchmark.out
+          {
+            echo '```text'
+            cat benchmark.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  compare:
+    # Don't use matrix due to the runner spec cannot be chosen.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        id: setup-go
+        with:
+          go-version: 1.27.x
+          check-latest: true
+
+      - name: Comparison
+        run: |
+          run_benchmark() {
+            local version="$1"
+            local package="$2"
+
+            pushd "_benchmark/comparison/$version"
+            go get "$package@latest"
+
+            go test -bench . -benchmem -run '^$' -count 10 | tee benchmark.out
+            {
+              echo "## $version"
+              echo
+              echo '```text'
+              cat benchmark.out
+              echo '```'
+              echo
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            popd
+          }
+
+          echo "Go version: ${{ steps.setup-go.outputs.go-version }}" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+          run_benchmark v2 "github.com/yuin/goldmark/v2"
+          run_benchmark v1 "github.com/yuin/goldmark"

--- a/.github/workflows/benchmark-comparison.yaml
+++ b/.github/workflows/benchmark-comparison.yaml
@@ -27,22 +27,110 @@ jobs:
 
             pushd "_benchmark/comparison/$version"
             go get "$package@latest"
-
             go test -bench . -benchmem -run '^$' -count 10 | tee benchmark.out
+
             {
               echo "## $version"
+              echo
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            awk '
+              function comma(n, s, sign, result) {
+                sign = ""
+                if (n < 0) {
+                  sign = "-"
+                  n = -n
+                }
+
+                s = sprintf("%.0f", n)
+                result = ""
+
+                while (length(s) > 3) {
+                  result = "," substr(s, length(s) - 2, 3) result
+                  s = substr(s, 1, length(s) - 3)
+                }
+
+                return sign s result
+              }
+
+              # ns/op
+              /^Benchmark/ {
+                ns[++n] = $3
+                bytes[n] = $5
+              }
+
+              END {
+                # Sort ns/op
+                for (i = 1; i <= n; i++)
+                  for (j = i + 1; j <= n; j++)
+                    if (ns[i] > ns[j]) {
+                      tmp = ns[i]
+                      ns[i] = ns[j]
+                      ns[j] = tmp
+                    }
+
+                # Sort B/op
+                for (i = 1; i <= n; i++)
+                  for (j = i + 1; j <= n; j++)
+                    if (bytes[i] > bytes[j]) {
+                      tmp = bytes[i]
+                      bytes[i] = bytes[j]
+                      bytes[j] = tmp
+                    }
+
+                # ns/op statistics
+                ns_sum = 0
+                for (i = 1; i <= n; i++)
+                  ns_sum += ns[i]
+
+                if (n % 2)
+                  ns_median = ns[(n + 1) / 2]
+                else
+                  ns_median = (ns[n / 2] + ns[n / 2 + 1]) / 2
+
+                # B/op statistics
+                bytes_sum = 0
+                for (i = 1; i <= n; i++)
+                  bytes_sum += bytes[i]
+
+                if (n % 2)
+                  bytes_median = bytes[(n + 1) / 2]
+                else
+                  bytes_median = (bytes[n / 2] + bytes[n / 2 + 1]) / 2
+
+                printf "ns/op\n"
+                printf "* Min:     %s\n", comma(ns[1])
+                printf "* Max:     %s\n", comma(ns[n])
+                printf "* Median:  %s\n", comma(ns_median)
+                printf "* Average: %s\n", comma(ns_sum / n)
+                printf "\n"
+                printf "B/op\n"
+                printf "* Min:     %s\n", comma(bytes[1])
+                printf "* Max:     %s\n", comma(bytes[n])
+                printf "* Median:  %s\n", comma(bytes_median)
+                printf "* Average: %s\n", comma(bytes_sum / n)
+                printf "\n"
+              }
+              ' benchmark.out >> "$GITHUB_STEP_SUMMARY"
+
+            {
+              echo '<details>'
               echo
               echo '```text'
               cat benchmark.out
               echo '```'
+              echo
+              echo '</details>'
               echo
             } >> "$GITHUB_STEP_SUMMARY"
 
             popd
           }
 
-          echo "Go version: ${{ steps.setup-go.outputs.go-version }}" \
-            >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "Go version: ${{ steps.setup-go.outputs.go-version }}"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
 
           run_benchmark v2 "github.com/yuin/goldmark/v2"
           run_benchmark v1 "github.com/yuin/goldmark"

--- a/_benchmark/comparison/v1/benchmark_test.go
+++ b/_benchmark/comparison/v1/benchmark_test.go
@@ -1,0 +1,39 @@
+package benchmark
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/renderer/html"
+)
+
+func BenchmarkGoldmarkV1(b *testing.B) {
+	markdown := goldmark.New(
+		goldmark.WithRendererOptions(html.WithXHTML(), html.WithUnsafe()),
+	)
+	doBenchmark(b, func(source []byte) ([]byte, error) {
+		var out bytes.Buffer
+		err := markdown.Convert(source, &out)
+		return out.Bytes(), err
+	})
+}
+
+func doBenchmark(b *testing.B, render func(src []byte) ([]byte, error)) {
+	b.StopTimer()
+	source, err := os.ReadFile("../../go/_data.md")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := render(source)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(out) < 100 {
+			b.Fatal("No result")
+		}
+	}
+}

--- a/_benchmark/comparison/v1/go.mod
+++ b/_benchmark/comparison/v1/go.mod
@@ -2,4 +2,4 @@ module benchmark-comparison-v1
 
 go 1.27
 
-require github.com/yuin/goldmark v1.8.5
+require github.com/yuin/goldmark v1.8.6

--- a/_benchmark/comparison/v1/go.mod
+++ b/_benchmark/comparison/v1/go.mod
@@ -2,4 +2,4 @@ module benchmark-comparison-v1
 
 go 1.27
 
-require github.com/yuin/goldmark v1.8.6
+require github.com/yuin/goldmark v1.8.5

--- a/_benchmark/comparison/v1/go.mod
+++ b/_benchmark/comparison/v1/go.mod
@@ -1,0 +1,5 @@
+module benchmark-comparison-v1
+
+go 1.27
+
+require github.com/yuin/goldmark v1.8.5

--- a/_benchmark/comparison/v1/go.sum
+++ b/_benchmark/comparison/v1/go.sum
@@ -1,0 +1,2 @@
+github.com/yuin/goldmark v1.8.5 h1:r6N5afV5qj/5S4UTch8agZHJ8UxNCMwX7WjkkJam2NA=
+github.com/yuin/goldmark v1.8.5/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=

--- a/_benchmark/comparison/v2/benchmark_test.go
+++ b/_benchmark/comparison/v2/benchmark_test.go
@@ -1,0 +1,38 @@
+package benchmark
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/yuin/goldmark/v2/parser"
+	"github.com/yuin/goldmark/v2/renderer/html"
+)
+
+func BenchmarkGoldmarkV2(b *testing.B) {
+	p := parser.New()
+	r := html.New(html.WithXHTML(), html.WithUnsafe())
+	doBenchmark(b, func(source []byte) ([]byte, error) {
+		var out bytes.Buffer
+		err := r.Render(&out, source, p.Parse(source))
+		return out.Bytes(), err
+	})
+}
+
+func doBenchmark(b *testing.B, render func(src []byte) ([]byte, error)) {
+	b.StopTimer()
+	source, err := os.ReadFile("../../go/_data.md")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := render(source)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(out) < 100 {
+			b.Fatal("No result")
+		}
+	}
+}

--- a/_benchmark/comparison/v2/go.mod
+++ b/_benchmark/comparison/v2/go.mod
@@ -1,0 +1,5 @@
+module benchmark-comparison-v2
+
+go 1.27
+
+require github.com/yuin/goldmark/v2 v2.0.0

--- a/_benchmark/comparison/v2/go.mod
+++ b/_benchmark/comparison/v2/go.mod
@@ -2,4 +2,4 @@ module benchmark-comparison-v2
 
 go 1.27
 
-require github.com/yuin/goldmark/v2 v2.0.1
+require github.com/yuin/goldmark/v2 v2.0.0

--- a/_benchmark/comparison/v2/go.mod
+++ b/_benchmark/comparison/v2/go.mod
@@ -2,4 +2,4 @@ module benchmark-comparison-v2
 
 go 1.27
 
-require github.com/yuin/goldmark/v2 v2.0.0
+require github.com/yuin/goldmark/v2 v2.0.1

--- a/_benchmark/comparison/v2/go.sum
+++ b/_benchmark/comparison/v2/go.sum
@@ -1,0 +1,2 @@
+github.com/yuin/goldmark/v2 v2.0.0 h1:P6JP1Px30eqo339He8dDFE8D0BSM21eQcbozLWH+E6g=
+github.com/yuin/goldmark/v2 v2.0.0/go.mod h1:G6M4/qOFtfn01/o14BU1UR2Lo5N3S9Qo7xCuz/sHjGQ=


### PR DESCRIPTION
This PR adds another v1/v2 performance comparison and GH Action to see the result in the web browser.

sample: https://github.com/sator-imaging/yuin--goldmark/actions/runs/34911925633