### PR TITLE
fix(extension): strip trailing punctuation exposed by an unmatched ')' in linkify

### DIFF
--- a/extension/_test/linkify.txt
+++ b/extension/_test/linkify.txt
@@ -208,3 +208,23 @@ https://example.org/).
 <p><a href="https://example.org/">https://example.org/</a>).</p>
 <p>(<a href="https://example.org/path_(x)">https://example.org/path_(x)</a>).</p>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
+
+
+21: Trailing punctuation exposed by an unmatched ')' is stripped
+//- - - - - - - - -//
+(https://example.com/path.)
+
+(https://example.com/path,)
+
+(www.example.com/x.)
+
+(https://example.com/a&amp;).
+
+(https://example.org/path_(x).)
+//- - - - - - - - -//
+<p>(<a href="https://example.com/path">https://example.com/path</a>.)</p>
+<p>(<a href="https://example.com/path">https://example.com/path</a>,)</p>
+<p>(<a href="http://www.example.com/x">www.example.com/x</a>.)</p>
+<p>(<a href="https://example.com/a">https://example.com/a</a>&amp;).</p>
+<p>(<a href="https://example.org/path_(x)">https://example.org/path_(x)</a>.)</p>
+//= = = = = = = = = = = = = = = = = = = = = = = =//

--- a/extension/linkify.go
+++ b/extension/linkify.go
@@ -244,31 +244,36 @@ func (s *linkifyParser) Parse(parent ast.Node, block text.Reader, pc parser.Cont
 		s := segment.WithStop(segment.Start + 1)
 		ast.MergeOrAppendTextSegment(parent, s)
 	}
-	i := m[1] - 1
-	for ; i > 0; i-- {
-		c := line[i]
-		switch c {
+	opening := bytes.Count(line[:m[1]], []byte{'('})
+	closing := bytes.Count(line[:m[1]], []byte{')'})
+	i := m[1]
+	for i > 1 {
+		switch line[i-1] {
 		case '?', '!', '.', ',', ':', '*', '_', '~':
+			i--
+		case ')':
+			if closing <= opening {
+				goto endfor
+			}
+			closing--
+			i--
+		case ';':
+			j := i - 2
+			for ; j > 0; j-- {
+				if util.IsAlphaNumeric(line[j]) {
+					continue
+				}
+				break
+			}
+			if j == i-2 || line[j] != '&' {
+				goto endfor
+			}
+			i = j
 		default:
 			goto endfor
 		}
 	}
 endfor:
-	i++
-	if line[i-1] == ')' {
-		i -= max(0, bytes.Count(line[:i], []byte{')'})-bytes.Count(line[:i], []byte{'('}))
-	} else if line[i-1] == ';' {
-		j := i - 2
-		for ; j >= m[0]; j-- {
-			if util.IsAlphaNumeric(line[j]) {
-				continue
-			}
-			break
-		}
-		if j != i-2 && line[j] == '&' {
-			i = j
-		}
-	}
 	consumes += i
 	block.Advance(consumes)
 	n := ast.NewTextSegment(text.NewSegment(start, start+i))


### PR DESCRIPTION
Fixes #580

**What**

Since c52d4b3 (the #571 fix) the unmatched-`)` trim runs once, after the trailing-punctuation loop, so any punctuation that trim exposes stays in the autolink:

| input | v1.8.5 | v1.8.6 | this PR |
|---|---|---|---|
| `(https://example.com/path.)` | `…/path` | `…/path.` | `…/path` |
| `(https://example.com/path,)` | `…/path` | `…/path,` | `…/path` |
| `(www.example.com/x.)` | `…/x` | `…/x.` | `…/x` |

**Fix**

Fold the `)` and `&entity;` handling into the trailing loop, so the trims repeat until the end of the link is stable (one unmatched `)` per pass, like cmark-gfm's autolink extension). The paren balance is counted once up front and decremented as `)` are stripped, so a matched `)` (e.g. `https://example.org/path_(x)`) is still kept. The #571 cases (`https://example.org/a).`, `(https://example.org/).`) behave as before.

**Tests**

Added case 21 to `extension/_test/linkify.txt` with the issue's three inputs plus `(https://example.com/a&amp;).` and `(https://example.org/path_(x).)`.

**Validation**

- `go test ./extension/ -run TestLinkify` with the new case but the old `linkify.go` → `--- FAIL: TestLinkify` (case 21); with the fix → `ok`
- `go test ./...` → all packages ok (go 1.25.1, linux/amd64)
- `gofmt -l extension/` / `go vet ./extension/` → clean

Happy to adjust.
