### PR TITLE
fix(parser): make tab width position-aware on blank lines in indented code blocks

### DIFF
--- a/extra_test.go
+++ b/extra_test.go
@@ -303,3 +303,41 @@ func TestParseContext(t *testing.T) {
 	}
 
 }
+
+func TestBlankLineInIndentedCodeBlock(t *testing.T) {
+	markdown := testutil.NewMarkdownToStringFunc(
+		parser.New(),
+		html.New(html.WithXHTML(), html.WithUnsafe()),
+	)
+	for _, c := range []struct {
+		name     string
+		source   string
+		expected string
+	}{
+		// A tab only advances to the next tab stop, so the tabs below are
+		// narrower than four columns and leave no indentation of their own.
+		{"1 space + tab", "    a\n \t\n    b\n", "<pre><code>a\n\nb\n</code></pre>\n"},
+		{"2 spaces + tab", "    a\n  \t\n    b\n", "<pre><code>a\n\nb\n</code></pre>\n"},
+		{"3 spaces + tab", "    a\n   \t\n    b\n", "<pre><code>a\n\nb\n</code></pre>\n"},
+		{"2 spaces + tab + 2 spaces", "    a\n  \t  \n    b\n", "<pre><code>a\n  \nb\n</code></pre>\n"},
+		{"tab + 2 spaces in a block quote", ">     a\n> \t  \n>     b\n", "<blockquote>\n<pre><code>a\n\nb\n</code></pre>\n</blockquote>\n"},
+		{"tab split by a block quote marker", ">     a\n>\t \t\n>     b\n", "<blockquote>\n<pre><code>a\n  \nb\n</code></pre>\n</blockquote>\n"},
+
+		{"tab", "    a\n\t\n    b\n", "<pre><code>a\n\nb\n</code></pre>\n"},
+		{"tab + tab", "    a\n\t\t\n    b\n", "<pre><code>a\n\t\nb\n</code></pre>\n"},
+		{"4 spaces", "    a\n    \n    b\n", "<pre><code>a\n\nb\n</code></pre>\n"},
+		{"6 spaces", "    a\n      \n    b\n", "<pre><code>a\n  \nb\n</code></pre>\n"},
+		{"8 spaces", "    a\n        \n    b\n", "<pre><code>a\n    \nb\n</code></pre>\n"},
+		{"4 spaces in a block quote", ">     a\n>     \n>     b\n", "<blockquote>\n<pre><code>a\n\nb\n</code></pre>\n</blockquote>\n"},
+		{"tab + tab in a block quote", ">     a\n>\t\t\n>     b\n", "<blockquote>\n<pre><code>a\n  \nb\n</code></pre>\n</blockquote>\n"},
+		{"tab + tab + 2 spaces in a tab indented block quote", ">\t     a\n>\t\t  \n>\t     b\n", "<blockquote>\n<pre><code>   a\n    \n   b\n</code></pre>\n</blockquote>\n"},
+	} {
+		out, err := markdown(c.source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out != c.expected {
+			t.Errorf("%s:\n source:   %q\n expected: %q\n got:      %q", c.name, c.source, c.expected, out)
+		}
+	}
+}

--- a/parser/code_block.go
+++ b/parser/code_block.go
@@ -45,7 +45,7 @@ func (b *codeBlockParser) Continue(node ast.Node, reader text.Reader, _ Context)
 	cb := node.(*ast.CodeBlock)
 	line, segment := reader.PeekLine()
 	if util.IsBlank(line) {
-		cb.Value.AppendSegment(segment.TrimLeftSpaceWidth(4, reader.Source()))
+		cb.Value.AppendSegment(segment.TrimLeftSpaceWidthAt(4, reader.LineOffset(), reader.Source()))
 		return Continue | NoChildren
 	}
 	pos, padding := util.IndentPosition(line, reader.LineOffset(), 4)

--- a/text/value.go
+++ b/text/value.go
@@ -756,14 +756,23 @@ func (t Segment) TrimLeftSpace(source []byte) Segment {
 }
 
 // TrimLeftSpaceWidth returns a new segment by slicing off leading space
-// characters until the given width.
+// characters until the given width, assuming that the segment starts at
+// the beginning of a line.
 func (t Segment) TrimLeftSpaceWidth(width int, source []byte) Segment {
+	return t.TrimLeftSpaceWidthAt(width, 0, source)
+}
+
+// TrimLeftSpaceWidthAt returns a new segment by slicing off leading space
+// characters until the given width. currentPos is the column at which the
+// segment starts and determines how wide leading tab characters are.
+func (t Segment) TrimLeftSpaceWidthAt(width, currentPos int, source []byte) Segment {
 	padding := t.Padding
 	for ; width > 0; width-- {
 		if padding == 0 {
 			break
 		}
 		padding--
+		currentPos++
 	}
 	if width == 0 {
 		return NewSegmentPadding(t.Start, t.Stop, padding)
@@ -778,8 +787,11 @@ loop:
 		switch c {
 		case ' ':
 			width--
+			currentPos++
 		case '\t':
-			width -= 4
+			w := util.TabWidth(currentPos)
+			width -= w
+			currentPos += w
 		default:
 			break loop
 		}

--- a/text/value_test.go
+++ b/text/value_test.go
@@ -1,0 +1,37 @@
+package text_test
+
+import (
+	"testing"
+
+	"github.com/yuin/goldmark/v2/text"
+)
+
+func TestSegmentTrimLeftSpaceWidth(t *testing.T) {
+	source := []byte("\t  foo")
+	for _, c := range []struct {
+		name       string
+		segment    text.Segment
+		width      int
+		currentPos int
+		expected   string
+	}{
+		// A tab at the third column is only two columns wide, so trimming four
+		// columns eats the two spaces that follow it as well.
+		{"tab at the start of a line", text.NewSegment(0, len(source)), 4, 0, "  foo"},
+		{"tab at the third column", text.NewSegment(0, len(source)), 4, 2, "foo"},
+		{"tab after two columns of padding", text.NewSegmentPadding(0, len(source), 2), 4, 0, "  foo"},
+		{"spaces", text.NewSegment(1, len(source)), 1, 0, " foo"},
+	} {
+		got := string(c.segment.TrimLeftSpaceWidthAt(c.width, c.currentPos, source).Bytes(source))
+		if got != c.expected {
+			t.Errorf("%s: TrimLeftSpaceWidthAt(%d, %d): expected %q, got %q", c.name, c.width, c.currentPos, c.expected, got)
+		}
+		if c.currentPos != 0 {
+			continue
+		}
+		got = string(c.segment.TrimLeftSpaceWidth(c.width, source).Bytes(source))
+		if got != c.expected {
+			t.Errorf("%s: TrimLeftSpaceWidth(%d): expected %q, got %q", c.name, c.width, c.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
## The bug

A blank line inside an indented code block loses its indentation to the wrong amount whenever the line contains a tab that does not start at a tab stop.

```go
markdown.Convert([]byte("    a\n  \t\n    b\n"), &buf)
```

`  \t` is 2 spaces followed by a tab. The tab only advances to the next tab stop, i.e. 2 more columns, so the line is exactly 4 columns wide and should contribute no indentation. goldmark counts the tab as 4, calls the line 6 columns wide, and leaks 2 spaces into the code block.

## The odd one out

`codeBlockParser.Continue` measures the same line two different ways, three lines apart, in the same function:

```go
// parser/code_block.go:44
func (b *codeBlockParser) Continue(node ast.Node, reader text.Reader, _ Context) State {
	cb := node.(*ast.CodeBlock)
	line, segment := reader.PeekLine()
	if util.IsBlank(line) {
		cb.Value.AppendSegment(segment.TrimLeftSpaceWidth(4, reader.Source()))   // :48  position-blind
		return Continue | NoChildren
	}
	pos, padding := util.IndentPosition(line, reader.LineOffset(), 4)            // :51  position-aware
```

`Open` at `parser/code_block.go:26` is position-aware too. The blank-line branch at `:48` is the only place in the block parser that measures indentation without knowing what column it starts at, because `Segment.TrimLeftSpaceWidth` hardcodes the width:

```go
// text/value.go:782
case '\t':
	width -= 4
```

Your own helpers already do this correctly. `util.TabWidth` at `util/util.go:136` is `4 - currentPos%4`, and both indentation scanners feed the running column back into it:

```go
util/util.go:172   w += TabWidth(currentPos + w)        // IndentPosition
util/util.go:193   width += TabWidth(currentPos + width) // IndentWidth
```

`AGENTS.md:29` states the invariant this branch violates:

> - Tabs can be 1,2,3,4 spaces or raw tab character, depending on its position. When parsing block elements, you should aware of this and calculate the correct indentation level.

The blank-line branch returns at `:49`, before reaching `preserveLeadingTabInCodeBlock` at `:60`, so nothing downstream compensates. `TrimLeftSpaceWidth` had exactly one call site in the repo (`parser/code_block.go:48`) and no test coverage, which is why the 652 passing spec examples never caught it: the `Tabs` section of `_test/spec.json` has no blank-line-inside-an-indented-code-block case.

## Before / after

Run against `master` at cae0983, all six rows are wrong:

| source | expected | before |
|---|---|---|
| `"    a\n \t\n    b\n"` | `<pre><code>a\n\nb\n</code></pre>` | `<pre><code>a\n \nb\n</code></pre>` |
| `"    a\n  \t\n    b\n"` | `<pre><code>a\n\nb\n</code></pre>` | `<pre><code>a\n  \nb\n</code></pre>` |
| `"    a\n   \t\n    b\n"` | `<pre><code>a\n\nb\n</code></pre>` | `<pre><code>a\n   \nb\n</code></pre>` |
| `"    a\n  \t  \n    b\n"` | `<pre><code>a\n  \nb\n</code></pre>` | `<pre><code>a\n    \nb\n</code></pre>` |
| `">     a\n> \t  \n>     b\n"` | `<blockquote>...a\n\nb\n...` | `<blockquote>...a\n  \nb\n...` |
| `">     a\n>\t \t\n>     b\n"` | `<blockquote>...a\n  \nb\n...` | `<blockquote>...a\n   \nb\n...` |

The last two matter because a block quote marker shifts the column the code line starts at, so the tab width depends on `reader.LineOffset()` and not just on the bytes of the line.

## The fix

`Segment.TrimLeftSpaceWidthAt` takes the column the segment starts at and measures tabs with `util.TabWidth`. `TrimLeftSpaceWidth` becomes a delegating wrapper passing `0`, so the released signature is unchanged. This mirrors the `util.IndentPosition` (`util/util.go:150`) / `util.IndentPositionPadding` (`:157`) pair you already ship.

It belongs in `text` rather than in the parser because `Segment.Bytes` (`text/value.go:693`) materializes `Padding` as literal space bytes. A `pos` obtained from `util.IndentPosition` would index a buffer that contains that synthetic padding, so `segment.Start + pos` is wrong whenever `Padding != 0` -- which is exactly the block quote case. Reusing the segment's own padding bookkeeping also handles blank lines shorter than the requested width for free.

## Verification

- `make test` -- both rows green, including `cd parser && go test -tags=goldmark_v1_attribute .`
- `make lint` -- `golangci-lint run -c .golangci.yml ./...` reports 0 issues; the `gopls check -severity hint` sweep is silent
- Mutation-checked in both directions. Reverting the tab branch to `width -= 4`, passing a literal `0` at the call site, dropping either `currentPos++`, and using `TabWidth(currentPos) + 1` each fail the new tests. Seeding the wrapper's `currentPos` with `t.Padding` is invisible to the integration tests, which is what `text/value_test.go` is for.
- Cross-checked 45 shapes (15 blank-line forms x 3 block quote prefixes) against `markdown_it.MarkdownIt('commonmark')`. 0 mismatches after normalizing the raw tabs that `preserveLeadingTabInCodeBlock` deliberately keeps through a 4-column tab expander. The oracle was validated first against your own spec example 6 (`>\t\tfoo\n`).

## Benchmark

Per `AGENTS.md:14-15`. `_benchmark/cmark/goldmark_benchmark.go 500 _data.md`, binaries built once with `go build`, order alternated each rep, 30 reps per side:

```
before ms: min=2.4311  p10=2.4428  median=2.5019   (sd 0.135)
after  ms: min=2.4218  p10=2.4478  median=2.4923   (sd 0.139)
delta      min -0.38%  p10 +0.20%  median -0.38%
```

No measurable change. The new branch only executes on blank lines inside indented code blocks.

## PR checklist

- [x] This is a CommonMark correctness fix in the core parser, not a non-CommonMark feature. No new syntax or options are added.
- [x] Not a question about the CommonMark spec. The expected output is confirmed against a reference CommonMark implementation, above.

---

Disclosure: this patch was prepared with AI assistance. I have reviewed the diff, run the repo's own gates, and stand behind the analysis and the measurements above.
