### PR TITLE
fix(extension): render transitively referenced footnotes

### DIFF
--- a/extension/footnote.go
+++ b/extension/footnote.go
@@ -549,32 +549,76 @@ func (d *footnoteDecorator) Decorate(next html.NodeRenderer) html.NodeRenderer {
 		if entering {
 			defsMap := map[string]*ast.FootnoteDefinition{}
 			infos := map[string]*defInfo{}
+			collectReference := func(ref *ast.FootnoteReference) (string, bool) {
+				label := ref.Label.Str(source)
+				info, exists := infos[label]
+				if !exists {
+					info = &defInfo{index: -1}
+					infos[label] = info
+				}
+				if info.index < 0 {
+					info.index = ref.Index
+				}
+				first := len(info.references) == 0
+				info.references = append(info.references, ref.RefIndex)
+				return label, first
+			}
+			var definitions []*ast.FootnoteDefinition
+			var hasNestedReferences map[*ast.FootnoteDefinition]bool
 			_ = gast.Walk(node, func(node gast.Node, entering bool) (gast.WalkStatus, error) {
+				if def, ok := node.(*ast.FootnoteDefinition); ok {
+					if entering {
+						label := def.Label.Str(source)
+						defsMap[label] = def
+						definitions = append(definitions, def)
+					} else {
+						definitions = definitions[:len(definitions)-1]
+					}
+					return gast.WalkContinue, nil
+				}
 				if !entering {
 					return gast.WalkContinue, nil
 				}
-				if def, ok := node.(*ast.FootnoteDefinition); ok {
-					label := def.Label.Str(source)
-					defsMap[label] = def
-					if _, exists := infos[label]; !exists {
-						infos[label] = &defInfo{index: -1}
-					}
-					return gast.WalkSkipChildren, nil
-				}
 				if ref, ok := node.(*ast.FootnoteReference); ok {
-					label := ref.Label.Str(source)
-					info, exists := infos[label]
-					if !exists {
-						info = &defInfo{index: -1}
-						infos[label] = info
+					if len(definitions) == 0 {
+						collectReference(ref)
+					} else {
+						if hasNestedReferences == nil {
+							hasNestedReferences = map[*ast.FootnoteDefinition]bool{}
+						}
+						hasNestedReferences[definitions[len(definitions)-1]] = true
 					}
-					if info.index < 0 {
-						info.index = ref.Index
-					}
-					info.references = append(info.references, ref.RefIndex)
 				}
 				return gast.WalkContinue, nil
 			})
+			pending := make([]string, 0, len(infos))
+			for label := range infos {
+				pending = append(pending, label)
+			}
+			// References in unused definitions must not make other notes visible.
+			for i := 0; i < len(pending); i++ {
+				def := defsMap[pending[i]]
+				if def == nil || !hasNestedReferences[def] {
+					continue
+				}
+				_ = gast.Walk(def, func(node gast.Node, entering bool) (gast.WalkStatus, error) {
+					if !entering {
+						return gast.WalkContinue, nil
+					}
+					if nested, ok := node.(*ast.FootnoteDefinition); ok && nested != def {
+						return gast.WalkSkipChildren, nil
+					}
+					if ref, ok := node.(*ast.FootnoteReference); ok {
+						if label, first := collectReference(ref); first {
+							pending = append(pending, label)
+						}
+					}
+					return gast.WalkContinue, nil
+				})
+			}
+			for _, info := range infos {
+				slices.Sort(info.references)
+			}
 			rc.Set(footnoteDefsKey, defsMap)
 			rc.Set(footnoteDefsInfoKey, infos)
 

--- a/extension/footnote_nested_test.go
+++ b/extension/footnote_nested_test.go
@@ -1,0 +1,198 @@
+package extension
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/yuin/goldmark/v2/parser"
+	"github.com/yuin/goldmark/v2/renderer/html"
+	"github.com/yuin/goldmark/v2/testutil"
+	"github.com/yuin/goldmark/v2/util"
+)
+
+func BenchmarkFootnoteRender(b *testing.B) {
+	for _, name := range []string{"flat", "unused"} {
+		b.Run(name, func(b *testing.B) {
+			var input strings.Builder
+			input.WriteString("Document.\n\n")
+			if name == "flat" {
+				for i := range 50 {
+					fmt.Fprintf(&input, "Root[^n%d] ", i)
+				}
+				input.WriteString("\n\n")
+			}
+			for i := range 50 {
+				fmt.Fprintf(&input, "[^n%d]: Some footnote text for item %d.", i, i)
+				if name == "unused" {
+					fmt.Fprintf(&input, "[^n%d]", (i+1)%50)
+				}
+				input.WriteString("\n\n")
+			}
+			source := util.StringToReadOnlyBytes(input.String())
+			p := parser.New(parser.WithExtensions(NewFootnoteParser()))
+			r := html.New(html.WithExtensions(NewFootnoteHTMLRenderer()))
+			var output bytes.Buffer
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				output.Reset()
+				if err := r.Render(&output, source, p.Parse(source)); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func TestFootnoteNestedReferences(t *testing.T) {
+	definitions := regexp.MustCompile(`<li id="([^"]+)"`)
+	backlinks := regexp.MustCompile(`href="#([^"]+)" class="footnote-backref"`)
+	ids := regexp.MustCompile(` id="([^"]+)"`)
+	hrefs := regexp.MustCompile(`href="#([^"]+)"`)
+	values := func(pattern *regexp.Regexp, output string) []string {
+		var result []string
+		for _, match := range pattern.FindAllStringSubmatch(output, -1) {
+			result = append(result, match[1])
+		}
+		return result
+	}
+
+	for _, tc := range []struct {
+		name        string
+		source      string
+		options     []FootnoteHTMLRendererOption
+		definitions []string
+		backlinks   []string
+		contains    []string
+		omits       []string
+	}{
+		{
+			name:        "nested reference",
+			source:      "Parent[^p]\n\n[^p]: parent-body[^c]\n[^c]: child-body\n",
+			definitions: []string{"fn:1", "fn:2"},
+			backlinks:   []string{"fnref:1", "fnref:2"},
+			contains:    []string{"parent-body", "child-body"},
+		},
+		{
+			name:        "chain",
+			source:      "Root[^a]\n\n[^a]: a-body[^b]\n[^b]: b-body[^c]\n[^c]: c-body\n",
+			definitions: []string{"fn:1", "fn:2", "fn:3"},
+			backlinks:   []string{"fnref:1", "fnref:2", "fnref:3"},
+			contains:    []string{"a-body", "b-body", "c-body"},
+		},
+		{
+			name:        "shared child",
+			source:      "First[^a] and second[^b]\n\n[^a]: a-body[^c]\n[^b]: b-body[^c]\n[^c]: c-body\n",
+			definitions: []string{"fn:1", "fn:2", "fn:3"},
+			backlinks:   []string{"fnref:1", "fnref:2", "fnref:3", "fnref1:3"},
+			contains:    []string{"a-body", "b-body", "c-body"},
+		},
+		{
+			name:        "backlinks keep their reference order",
+			source:      "Root[^a]\n\n[^a]: a-body[^b]\n\nChild[^b]\n\n[^b]: b-body\n",
+			definitions: []string{"fn:1", "fn:2"},
+			backlinks:   []string{"fnref:1", "fnref:2", "fnref1:2"},
+			contains:    []string{"a-body", "b-body"},
+		},
+		{
+			name:        "self reference",
+			source:      "Root[^a]\n\n[^a]: a-body[^a]\n",
+			definitions: []string{"fn:1"},
+			backlinks:   []string{"fnref:1", "fnref1:1"},
+			contains:    []string{"a-body"},
+		},
+		{
+			name:        "cycle",
+			source:      "Root[^a]\n\n[^a]: a-body[^b]\n[^b]: b-body[^a]\n",
+			definitions: []string{"fn:1", "fn:2"},
+			backlinks:   []string{"fnref:1", "fnref1:1", "fnref:2"},
+			contains:    []string{"a-body", "b-body"},
+		},
+		{
+			name:        "unreferenced chain stays hidden",
+			source:      "Root[^a]\n\n[^a]: a-body\n[^u]: unused-body[^v]\n[^v]: hidden-body\n",
+			definitions: []string{"fn:1"},
+			backlinks:   []string{"fnref:1"},
+			contains:    []string{"a-body"},
+			omits:       []string{"unused-body", "hidden-body"},
+		},
+		{
+			name:     "unreferenced cycle stays hidden",
+			source:   "Text.\n\n[^u]: unused-body[^v]\n[^v]: hidden-body[^u]\n",
+			contains: []string{"<p>Text.</p>"},
+			omits:    []string{"unused-body", "hidden-body", "doc-endnotes"},
+		},
+		{
+			name:        "definition inside an unreferenced definition",
+			source:      "Child[^c]\n\n[^p]: parent-body\n\n    [^c]: child-body\n",
+			definitions: []string{"fn:1"},
+			backlinks:   []string{"fnref:1"},
+			contains:    []string{"child-body"},
+			omits:       []string{"parent-body"},
+		},
+		{
+			name:        "prefixed references and metadata",
+			source:      "Parent[^p]\n\n[^p]: parent-body[^c]\n[^c]: child-body\n",
+			options:     []FootnoteHTMLRendererOption{WithIDPrefix("doc-"), WithLinkTitle("refs=%%")},
+			definitions: []string{"doc-fn:1", "doc-fn:2"},
+			backlinks:   []string{"doc-fnref:1", "doc-fnref:2"},
+			contains:    []string{"child-body", `title="refs=1"`},
+			omits:       []string{`title="refs=0"`},
+		},
+		{
+			name:        "reference to a nested definition",
+			source:      "Parent[^p]\n\n[^p]: parent-body[^c]\n\n    [^c]: child-body\n",
+			definitions: []string{"fn:1", "fn:2"},
+			backlinks:   []string{"fnref:1", "fnref:2"},
+			contains:    []string{"parent-body", "child-body"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if caught := recover(); caught != nil {
+					t.Errorf("render panicked: %v", caught)
+				}
+			}()
+			markdown := testutil.NewMarkdownToStringFunc(
+				parser.New(parser.WithExtensions(NewFootnoteParser())),
+				html.New(html.WithExtensions(NewFootnoteHTMLRenderer(tc.options...))),
+			)
+			output, err := markdown(tc.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := values(definitions, output); !slices.Equal(got, tc.definitions) {
+				t.Errorf("definitions = %v, want %v", got, tc.definitions)
+			}
+			if got := values(backlinks, output); !slices.Equal(got, tc.backlinks) {
+				t.Errorf("backlinks = %v, want %v", got, tc.backlinks)
+			}
+			seen := map[string]bool{}
+			for _, id := range values(ids, output) {
+				if seen[id] {
+					t.Errorf("duplicate id %q", id)
+				}
+				seen[id] = true
+			}
+			for _, target := range values(hrefs, output) {
+				if !seen[target] {
+					t.Errorf("missing target for href #%s", target)
+				}
+			}
+			for _, want := range tc.contains {
+				if !strings.Contains(output, want) {
+					t.Errorf("output does not contain %q", want)
+				}
+			}
+			for _, unwanted := range tc.omits {
+				if strings.Contains(output, unwanted) {
+					t.Errorf("output contains %q", unwanted)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs: #584

The v2 footnote renderer collected document references but skipped references inside footnote definitions. A nested reference could therefore point to a definition that was never rendered; physically nested definitions could also cause a panic.

This indexes definitions separately, then follows references reachable from the document. Each newly referenced definition is queued once, so cycles terminate and unused definitions stay hidden. Leaf definitions are not rescanned, and backlinks retain their existing reference-index order.

Parser numbering and the separate v1 ordering question in #410 are unchanged.

### Validation

- Eleven regression/control cases cover chains, shared children, self-reference, cycles, nested definitions, prefixes, counts, and hidden unused notes. Nine fail on the original code; all pass with the fix.
- `make test` passes with Go 1.25.14, 1.26.8 and 1.27.1, including README examples.
- Full `go test -race ./...` passes.
- `make lint` passes with both root and `_benchmark/go` modules in a local workspace; no tracked module files change.
- 1,000 additional fixed-seed graph cases pass; the baseline fails 752.
- `make bench` ran before/after. Added `BenchmarkFootnoteRender` makes the changed extension path reproducible; the default CommonMark benchmark does not link this extension.

Ten balanced-order samples of the new 50-note benchmark show the following allocation costs:

| Case | Before allocs/op | After allocs/op |
| --- | ---: | ---: |
| flat | 662 | 664 |
| unused | 555 | 507 |

The flat case pays a small queue/stack allocation cost. Timings vary across runs, so this is not a general speedup claim.
